### PR TITLE
prelude: Remove import of embedded-hal prelude

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,3 @@
 //! Prelude
-pub use embedded_hal::prelude::*;
 
 pub use fugit::{ExtU32 as _, RateExtU32 as _};


### PR DESCRIPTION
embedded-hal 1.0 does not have a prelude to import (0.27 did).