### PR TITLE
examples: Add rcc and fractional-pll examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ paste = "1.0.15"
 log = { version = "0.4.20", optional = true}
 
 [dev-dependencies]
+log = { version = "0.4.20"}
 cortex-m-rt = "0.7.3"
 panic-halt = "0.2.0"
 panic-rtt-target = { version = "0.1.0", features = ["cortex-m"] }

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -13,7 +13,11 @@ fn main() -> ! {
     let dp = pac::Peripherals::take().unwrap();
 
     let pwr = dp.PWR.constrain();
-    let _pwrcfg = pwr.vos0().freeze();
+    let pwrcfg = pwr.vos0().freeze();
+
+    // Constrain and Freeze clock
+    let rcc = dp.RCC.constrain();
+    let _ccdr = rcc.sys_ck(250.MHz()).freeze(pwrcfg, &dp.SBS);
 
     dp.GPIOA.moder().write(|w| w.mode5().output()); // output
     dp.GPIOA.pupdr().write(|w| w.pupd5().pull_up()); // pull-up

--- a/examples/fractional-pll.rs
+++ b/examples/fractional-pll.rs
@@ -1,0 +1,57 @@
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+#[macro_use]
+mod utilities;
+
+use cortex_m_rt::entry;
+use log::info;
+use stm32h5xx_hal::rcc;
+use stm32h5xx_hal::{pac, prelude::*};
+
+#[entry]
+fn main() -> ! {
+    utilities::logger::init();
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Constrain and Freeze power
+    info!("Setup PWR...                  ");
+    let pwr = dp.PWR.constrain();
+    let pwrcfg = pwr.vos0().freeze();
+
+    // Constrain and Freeze clock
+    info!("Setup RCC...                  ");
+    let rcc = dp.RCC.constrain();
+    let ccdr = rcc
+        .sys_ck(250.MHz())
+        .pll2_strategy(rcc::PllConfigStrategy::Fractional)
+        .pll2_p_ck(12_288_000.Hz())
+        .pll2_q_ck(6_144_000.Hz())
+        .pll2_r_ck(3_024_000.Hz())
+        // pll2_p / 2 --> mco2
+        .mco2_from_pll2_p_ck(7.MHz())
+        .freeze(pwrcfg, &dp.SBS);
+
+    // // Enable MCO2 output pin
+    // let gpioc = dp.GPIOC.split(ccdr.peripheral.GPIOC);
+    // let _mco2_pin = gpioc.pc9.into_alternate::<0>().speed(Speed::High);
+
+    info!("");
+    info!("stm32h5xx-hal example - Fractional PLL");
+    info!("");
+
+    // SYS_CK
+    info!("sys_ck = {} Hz", ccdr.clocks.sys_ck().raw());
+    assert_eq!(ccdr.clocks.sys_ck().raw(), 250_000_000);
+
+    info!("pll2_p_ck = {}", ccdr.clocks.pll2_p_ck().unwrap());
+    info!("pll2_q_ck = {}", ccdr.clocks.pll2_q_ck().unwrap());
+    info!("pll2_r_ck = {}", ccdr.clocks.pll2_r_ck().unwrap());
+
+    let _mco2_ck = ccdr.clocks.mco2_ck().unwrap().raw();
+
+    loop {
+        cortex_m::asm::nop()
+    }
+}

--- a/examples/rcc.rs
+++ b/examples/rcc.rs
@@ -1,0 +1,44 @@
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+#[macro_use]
+mod utilities;
+
+use log::info;
+
+use cortex_m_rt::entry;
+use stm32h5xx_hal::{pac, prelude::*};
+
+#[entry]
+fn main() -> ! {
+    utilities::logger::init();
+
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Constrain and Freeze power
+    info!("Setup PWR...                  ");
+    let pwr = dp.PWR.constrain();
+    let pwrcfg = pwr.vos0().freeze();
+
+    // Constrain and Freeze clock
+    info!("Setup RCC...                  ");
+    let rcc = dp.RCC.constrain();
+    let ccdr = rcc.sys_ck(250.MHz()).freeze(pwrcfg, &dp.SBS);
+
+    info!("");
+    info!("stm32h5xx-hal example - RCC");
+    info!("");
+
+    // HCLK
+    info!("hclk = {} Hz", ccdr.clocks.hclk().raw());
+    assert_eq!(ccdr.clocks.hclk().raw(), 250_000_000);
+
+    // SYS_CK
+    info!("sys_ck = {} Hz", ccdr.clocks.sys_ck().raw());
+    assert_eq!(ccdr.clocks.sys_ck().raw(), 250_000_000);
+
+    loop {
+        cortex_m::asm::nop()
+    }
+}


### PR DESCRIPTION
This adds 2 examples demonstrating RCC configuration. It also updates the blinky example to use the RCC to set up the MCU for 250MHz operation