### PR TITLE
clippy: fix new lint errors with 1.80

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,10 @@ stm32h562 = ["stm32h5/stm32h562", "device-selected", "rm0481"]
 stm32h563 = ["stm32h5/stm32h563", "device-selected", "rm0481"]
 stm32h573 = ["stm32h5/stm32h573", "device-selected", "rm0481"]
 # Flags for examples
-log-itm = ["dep:log"]
-log-rtt = ["dep:log"]
-log-semihost = ["dep:log"]
+log = ["dep:log"]
+log-itm = ["log"]
+log-rtt = ["log"]
+log-semihost = ["log"]
 
 [dependencies]
 cortex-m = { version = "^0.7.7", features = ["critical-section-single-core"] }

--- a/src/time.rs
+++ b/src/time.rs
@@ -31,6 +31,10 @@ pub struct Instant {
 }
 
 impl Instant {
+    pub fn new(now: u32) -> Self {
+        Self { now }
+    }
+
     /// Ticks elapsed since the `Instant` was created
     pub fn elapsed(&self) -> u32 {
         DWT::cycle_count().wrapping_sub(self.now)


### PR DESCRIPTION
Clippy added new lint errors with Rust 1.80 apparently, so fix them.