### PR TITLE
Fix version check script

### DIFF
--- a/tools/verify-rust-version.js
+++ b/tools/verify-rust-version.js
@@ -18,8 +18,6 @@ const cargo_toml_rust_version = cargo_toml_src.split('\n').filter(l => l.startsW
 
 console.log(`Rust version: ${cargo_toml_rust_version}`);
 
-let exitCode = 0;  // Non zero code indicates error
-
 for (const file of files) {
     const file_content = fs.readFileSync(file, 'UTF8').toString();
     const matches1 = file_content.match(re1);
@@ -29,7 +27,7 @@ for (const file of files) {
         for (const match of matches1) {
             if (match !== cargo_toml_rust_version.substring(0, 4)) {
                 console.error(`Found reference to version ${match}, expected ${cargo_toml_rust_version} in file ${file}`);
-                exitCode = 1;
+                proc.exitCode = 1; // Non zero code indicates error
             }
         }
     }
@@ -38,11 +36,9 @@ for (const file of files) {
         for (const match of matches2) {
             if (match !== cargo_toml_rust_version) {
                 console.error(`Found reference to version ${match}, expected ${cargo_toml_rust_version} in ${file}`);
-                exitCode = 1;
+                proc.exitCode = 1; // Non zero code indicates error
             }
         }
     }
 
 }
-
-proc.exitCode = exitCode;

--- a/tools/verify-rust-version.js
+++ b/tools/verify-rust-version.js
@@ -18,7 +18,7 @@ const cargo_toml_rust_version = cargo_toml_src.split('\n').filter(l => l.startsW
 
 console.log(`Rust version: ${cargo_toml_rust_version}`);
 
-let exitCode = 1;  // Non zero code indicates error
+let exitCode = 0;  // Non zero code indicates error
 
 for (const file of files) {
     const file_content = fs.readFileSync(file, 'UTF8').toString();
@@ -29,7 +29,7 @@ for (const file of files) {
         for (const match of matches1) {
             if (match !== cargo_toml_rust_version.substring(0, 4)) {
                 console.error(`Found reference to version ${match}, expected ${cargo_toml_rust_version} in file ${file}`);
-                exitCode = 0;
+                exitCode = 1;
             }
         }
     }
@@ -38,7 +38,7 @@ for (const file of files) {
         for (const match of matches2) {
             if (match !== cargo_toml_rust_version) {
                 console.error(`Found reference to version ${match}, expected ${cargo_toml_rust_version} in ${file}`);
-                exitCode = 0;
+                exitCode = 1;
             }
         }
     }

--- a/tools/verify-rust-version.js
+++ b/tools/verify-rust-version.js
@@ -18,7 +18,7 @@ const cargo_toml_rust_version = cargo_toml_src.split('\n').filter(l => l.startsW
 
 console.log(`Rust version: ${cargo_toml_rust_version}`);
 
-let error = false;
+let exitCode = 1;  // Non zero code indicates error
 
 for (const file of files) {
     const file_content = fs.readFileSync(file, 'UTF8').toString();
@@ -29,7 +29,7 @@ for (const file of files) {
         for (const match of matches1) {
             if (match !== cargo_toml_rust_version.substring(0, 4)) {
                 console.error(`Found reference to version ${match}, expected ${cargo_toml_rust_version} in file ${file}`);
-                error = true;
+                exitCode = 0;
             }
         }
     }
@@ -38,11 +38,11 @@ for (const file of files) {
         for (const match of matches2) {
             if (match !== cargo_toml_rust_version) {
                 console.error(`Found reference to version ${match}, expected ${cargo_toml_rust_version} in ${file}`);
-                error = true;
+                exitCode = 0;
             }
         }
     }
 
 }
 
-proc.exit(error);
+proc.exitCode = exitCode;


### PR DESCRIPTION
The Version check script started failing on master, but it was also crashing on exit, losing the error message. This fixes the exit code, in the way described in the Node.js documentation [here](https://nodejs.org/api/process.html#processexitcode)