### PR TITLE
examples: update blinky example to use GPIO driver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,3 +69,7 @@ codegen-units = 1 # better optimizations
 debug = true # symbols are nice and they don't increase the size in flash
 lto = true # better optimizations
 opt-level = "s" # optimize for binary size
+
+[[example]]
+name = "blinky"
+required-features = ["stm32h503"]


### PR DESCRIPTION
Use the recently completed GPIO driver in the blinky example