### PR TITLE
rcc: configure PLL3 for the rest of the H5 family

### DIFF
--- a/examples/fractional-pll.rs
+++ b/examples/fractional-pll.rs
@@ -45,9 +45,9 @@ fn main() -> ! {
     info!("sys_ck = {} Hz", ccdr.clocks.sys_ck().raw());
     assert_eq!(ccdr.clocks.sys_ck().raw(), 250_000_000);
 
-    info!("pll2_p_ck = {}", ccdr.clocks.pll2_p_ck().unwrap());
-    info!("pll2_q_ck = {}", ccdr.clocks.pll2_q_ck().unwrap());
-    info!("pll2_r_ck = {}", ccdr.clocks.pll2_r_ck().unwrap());
+    info!("pll2_p_ck = {}", ccdr.clocks.pll2().p_ck().unwrap());
+    info!("pll2_q_ck = {}", ccdr.clocks.pll2().q_ck().unwrap());
+    info!("pll2_r_ck = {}", ccdr.clocks.pll2().r_ck().unwrap());
 
     let _mco2_ck = ccdr.clocks.mco2_ck().unwrap().raw();
 

--- a/src/rcc/core_clocks.rs
+++ b/src/rcc/core_clocks.rs
@@ -2,6 +2,37 @@
 
 use crate::time::Hertz;
 
+#[derive(Clone, Copy)]
+pub struct PllClocks {
+    p_ck: Option<Hertz>,
+    q_ck: Option<Hertz>,
+    r_ck: Option<Hertz>,
+}
+
+impl PllClocks {
+    pub fn new(
+        p_ck: Option<Hertz>,
+        q_ck: Option<Hertz>,
+        r_ck: Option<Hertz>,
+    ) -> Self {
+        Self { p_ck, q_ck, r_ck }
+    }
+}
+
+impl PllClocks {
+    pub fn p_ck(&self) -> Option<Hertz> {
+        self.p_ck
+    }
+
+    pub fn q_ck(&self) -> Option<Hertz> {
+        self.q_ck
+    }
+
+    pub fn r_ck(&self) -> Option<Hertz> {
+        self.r_ck
+    }
+}
+
 /// Frozen core clock frequencies
 ///
 /// The existence of this value indicates that the core clock
@@ -25,12 +56,10 @@ pub struct CoreClocks {
     pub(super) audio_ck: Option<Hertz>,
     pub(super) mco1_ck: Option<Hertz>,
     pub(super) mco2_ck: Option<Hertz>,
-    pub(super) pll1_p_ck: Option<Hertz>,
-    pub(super) pll1_q_ck: Option<Hertz>,
-    pub(super) pll1_r_ck: Option<Hertz>,
-    pub(super) pll2_p_ck: Option<Hertz>,
-    pub(super) pll2_q_ck: Option<Hertz>,
-    pub(super) pll2_r_ck: Option<Hertz>,
+    pub(super) pll1: PllClocks,
+    pub(super) pll2: PllClocks,
+    #[cfg(feature = "rm0481")]
+    pub(super) pll3: PllClocks,
     pub(super) timx_ker_ck: Hertz,
     pub(super) timy_ker_ck: Hertz,
     pub(super) sys_ck: Hertz,
@@ -61,19 +90,6 @@ macro_rules! optional_ck_getter {
             /// is running, otherwise `None`
             pub fn $opt_ck(&self) -> Option<Hertz> {
                 self.$opt_ck
-            }
-        )+
-    };
-}
-
-/// Getters for pll clocks
-macro_rules! pll_getter {
-    ($($pll_ck:ident,)+) => {
-        $(
-            /// Returns `Some(frequency)` if the PLLx output is running,
-            /// otherwise `None`
-            pub fn $pll_ck(&self) -> Option<Hertz> {
-                self.$pll_ck
             }
         )+
     };
@@ -114,13 +130,20 @@ impl CoreClocks {
         self.mco2_ck
     }
 
-    pll_getter! {
-        pll1_p_ck,
-        pll1_q_ck,
-        pll1_r_ck,
-        pll2_p_ck,
-        pll2_q_ck,
-        pll2_r_ck,
+    /// Returns the configuration for PLL1
+    pub fn pll1(&self) -> PllClocks {
+        self.pll1
+    }
+
+    /// Returns the configuration for PLL2
+    pub fn pll2(&self) -> PllClocks {
+        self.pll2
+    }
+
+    #[cfg(feature = "rm0481")]
+    /// Returns the configuration for PLL3
+    pub fn pll3(&self) -> PllClocks {
+        self.pll3
     }
 
     /// Returns the input frequency to the SCGU

--- a/src/rcc/pll.rs
+++ b/src/rcc/pll.rs
@@ -328,6 +328,8 @@ fn calc_vco_ck(ref_ck: u32, pll_n: u32, pll_fracn: u16) -> u32 {
 impl Rcc {
     pll_setup! {pll1, false}
     pll_setup! {pll2, true}
+    #[cfg(feature = "rm0481")]
+    pll_setup! {pll3, true}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The STM32H523/STM32H533/STM32H56x/STM32H573 parts have a 3rd PLL. This configures them the same way PLL2 is configured. 

Caveat: I haven't tested configuration of PLL3 on one of the above parts as I don't have any.