### PR TITLE
i2c: Add target implementation

### DIFF
--- a/examples/i2c_target.rs
+++ b/examples/i2c_target.rs
@@ -1,0 +1,65 @@
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+#[macro_use]
+mod utilities;
+use stm32h5xx_hal::{
+    i2c::{TargetConfig, TargetListenEvent, Targetable},
+    pac,
+    prelude::*,
+};
+
+use cortex_m_rt::entry;
+
+use log::info;
+
+#[entry]
+fn main() -> ! {
+    utilities::logger::init();
+    log::set_max_level(log::LevelFilter::Debug);
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Constrain and Freeze power
+    info!("Setup PWR...                  ");
+    let pwr = dp.PWR.constrain();
+    let pwrcfg = pwr.freeze();
+
+    // Constrain and Freeze clock
+    info!("Setup RCC...                  ");
+    let rcc = dp.RCC.constrain();
+    let ccdr = rcc.sys_ck(100.MHz()).freeze(pwrcfg, &dp.SBS);
+
+    let gpiob = dp.GPIOB.split(ccdr.peripheral.GPIOB);
+
+    // Configure the SCL and the SDA pin for our I2C bus
+    let scl = gpiob.pb5.into_alternate_open_drain();
+    let sda = gpiob.pb3.into_alternate_open_drain();
+
+    info!("");
+    info!("stm32h5xx-hal example - I2C Target");
+    info!("");
+
+    let own_addr: u16 = 0x18;
+    let bus_freq_hz: u32 = 100_000;
+    let mut i2c = dp.I2C2.i2c_target_only(
+        (scl, sda),
+        TargetConfig::new(own_addr, bus_freq_hz),
+        ccdr.peripheral.I2C2,
+        &ccdr.clocks,
+    );
+
+    i2c.enable_listen_event(TargetListenEvent::PrimaryAddress);
+    let mut buf = [0u8; 2];
+
+    loop {
+        let count = i2c.wait_for_target_read(&mut buf).unwrap();
+        info!("Read {count} bytes: {:X?}", &buf[..count]);
+
+        let count = i2c.wait_for_target_write(b"Hello").unwrap();
+        info!("Wrote {count} bytes");
+
+        i2c.wait_for_stop().unwrap();
+        info!("==========");
+    }
+}

--- a/examples/i2c_target_manual_ack.rs
+++ b/examples/i2c_target_manual_ack.rs
@@ -1,0 +1,80 @@
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+#[macro_use]
+mod utilities;
+use stm32h5xx_hal::{
+    i2c::{TargetConfig, TargetEvent, TargetListenEvent, Targetable},
+    pac,
+    prelude::*,
+};
+
+use cortex_m_rt::entry;
+
+use log::info;
+
+#[entry]
+fn main() -> ! {
+    utilities::logger::init();
+    log::set_max_level(log::LevelFilter::Info);
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Constrain and Freeze power
+    info!("Setup PWR...                  ");
+    let pwr = dp.PWR.constrain();
+    let pwrcfg = pwr.freeze();
+
+    // Constrain and Freeze clock
+    info!("Setup RCC...                  ");
+    let rcc = dp.RCC.constrain();
+    let ccdr = rcc.sys_ck(100.MHz()).freeze(pwrcfg, &dp.SBS);
+
+    let gpiob = dp.GPIOB.split(ccdr.peripheral.GPIOB);
+
+    // Configure the SCL and the SDA pin for our I2C bus
+    let scl = gpiob.pb5.into_alternate_open_drain();
+    let sda = gpiob.pb3.into_alternate_open_drain();
+
+    info!("");
+    info!("stm32h5xx-hal example - I2C Target");
+    info!("");
+
+    let own_addr: u16 = 0x18;
+    let bus_freq_hz: u32 = 100_000;
+    let mut i2c = dp
+        .I2C2
+        .i2c_target_only(
+            (scl, sda),
+            TargetConfig::new(own_addr, bus_freq_hz),
+            ccdr.peripheral.I2C2,
+            &ccdr.clocks,
+        )
+        .with_manual_ack_control();
+
+    i2c.enable_listen_event(TargetListenEvent::PrimaryAddress);
+    let mut buf = [0u8; 2];
+
+    loop {
+        let event = i2c.wait_for_event().unwrap();
+        let result = match event {
+            TargetEvent::TargetWrite { address: _ } => i2c.write(b"Hello"),
+            TargetEvent::TargetRead { address: _ } => {
+                let result = i2c.read(&mut buf);
+                // An operation can be performed here while the clock is stretched low (ie.
+                // calculating or fetching data)
+                i2c.ack_transfer();
+                result
+            }
+            TargetEvent::Stop => Ok(0),
+        };
+
+        match result {
+            Err(error) => info!("Error: {event:?} - {error:?}"),
+            Ok(count) => match event {
+                TargetEvent::Stop => info!("=========="),
+                _ => info!("{event:?} ({count})"),
+            },
+        };
+    }
+}

--- a/src/i2c/config.rs
+++ b/src/i2c/config.rs
@@ -1,0 +1,71 @@
+use super::AddressMode;
+
+/// A structure for specifying the I2C Target configuration
+///
+/// This structure uses the builder pattern to generate the configuration:
+///
+/// ```
+/// let config = Config::new().secondary_address(0x10);
+/// ```
+#[derive(Copy, Clone)]
+pub struct TargetConfig {
+    /// Address mode of the MCU acting as a target
+    pub(crate) own_address_mode: AddressMode,
+    /// Target address for MCU
+    pub(crate) own_address: u16,
+    /// Secondary target address for MCU (7-bit only)
+    pub(crate) secondary_address: Option<u8>,
+    // Address mask for secondary mask
+    pub(crate) secondary_address_mask_bits: Option<u8>,
+    /// Frequency at which bus is expected to run.
+    pub(crate) bus_frequency_hz: u32,
+}
+
+impl TargetConfig {
+    /// Create a default configuration with the address of the MCU and the expected bus frequency.
+    ///
+    /// The address should be specified unshifted. 7-bit addressing mode is used by default.
+    ///
+    /// If this is not known, use a lower bound in order to ensure that the correct timing
+    /// parameters are used.
+    pub const fn new(own_address: u16, bus_frequency_hz: u32) -> Self {
+        TargetConfig {
+            own_address_mode: AddressMode::AddressMode7bit,
+            own_address,
+            secondary_address: None,
+            secondary_address_mask_bits: None,
+            bus_frequency_hz,
+        }
+    }
+
+    /// Set the primary address that the target will listen to. The address should be specified
+    /// unshifted. For 7-bit addresses the driver will shift it left by 1 to match the peripheral's
+    /// expectation. 10 bit addresses are not shifted.
+    pub const fn own_address(mut self, own_address: u16) -> Self {
+        self.own_address = own_address;
+        self
+    }
+
+    /// Set the addressing mode for the primary (own) address. Secondary addresses can only be
+    /// specified as 7 bit addresses.
+    pub const fn own_address_mode(mut self, address_mode: AddressMode) -> Self {
+        self.own_address_mode = address_mode;
+        self
+    }
+
+    /// Optional secondary 7-bit address for which the MCU can listen. This can also be masked
+    /// (using secondary_address_mask()) to enable the MCU to listen to a range of addresses. The
+    /// address should be specified unshifted. For 7-bit addresses the driver will shift it left by
+    /// 1 to match the peripheral's expectation.
+    pub const fn secondary_address(mut self, secondary_address: u8) -> Self {
+        self.secondary_address = Some(secondary_address);
+        self
+    }
+
+    /// Mask bits for secondary address. This allows the MCU to listen to a range of addresses. The
+    /// lower `mask_bits` bits will be masked.
+    pub const fn secondary_address_mask_bits(mut self, mask_bits: u8) -> Self {
+        self.secondary_address_mask_bits = Some(mask_bits);
+        self
+    }
+}

--- a/src/i2c/hal.rs
+++ b/src/i2c/hal.rs
@@ -11,11 +11,12 @@ impl i2c::Error for Error {
             Error::NotAcknowledge => {
                 i2c::ErrorKind::NoAcknowledge(i2c::NoAcknowledgeSource::Unknown)
             }
+            _ => i2c::ErrorKind::Other,
         }
     }
 }
 
-impl<I2C> i2c::ErrorType for I2c<I2C> {
+impl<I2C, R> i2c::ErrorType for I2c<I2C, R> {
     type Error = Error;
 }
 
@@ -40,7 +41,7 @@ impl OperationExt for i2c::Operation<'_> {
     }
 }
 
-impl<I2C: Instance> I2c<I2C> {
+impl<I2C: Instance, R> I2c<I2C, R> {
     fn process_operation(
         &mut self,
         stop: Stop,
@@ -123,7 +124,7 @@ impl<I2C: Instance> I2c<I2C> {
     }
 }
 
-impl<I2C: Instance> i2c::I2c<i2c::SevenBitAddress> for I2c<I2C> {
+impl<I2C: Instance, R> i2c::I2c<i2c::SevenBitAddress> for I2c<I2C, R> {
     fn transaction(
         &mut self,
         address: i2c::SevenBitAddress,
@@ -138,7 +139,7 @@ impl<I2C: Instance> i2c::I2c<i2c::SevenBitAddress> for I2c<I2C> {
     }
 }
 
-impl<I2C: Instance> i2c::I2c<i2c::TenBitAddress> for I2c<I2C> {
+impl<I2C: Instance, R> i2c::I2c<i2c::TenBitAddress> for I2c<I2C, R> {
     fn transaction(
         &mut self,
         address: i2c::TenBitAddress,


### PR DESCRIPTION
This extends the I2C driver to support target operation. It adds an I2cTarget type to represent the I2C operation as the target. 

Target operation can be operated in automatic ACKing mode, letting the hardware manage clock stretching and ACKing automatically, or it can be operated in manual ACK control mode, which lets the user of the driver determine when to ACK the end of a transaction. Manual ACK control allows for clock stretching while data is being processed or retrieved before ACK'ing the final byte of a transfer and initiating either the end of a transfer or a repeat start to read the processed/retrieved data. This implementation does not currently allow for ACKing individual or a subset of bytes manually, but extending the interface to do so can build upon what is implemented so far. 

This also adds role switching to the driver, enabling both controller and target implementation through choosing the appropriate initialization functions.