### PR TITLE
spi: Add SPI master implementation

### DIFF
--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -1,0 +1,68 @@
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use cortex_m_rt::entry;
+mod utilities;
+use embedded_hal::{delay::DelayNs, spi::SpiBus};
+use stm32h5xx_hal::{delay::Delay, pac, prelude::*, spi, time::MilliSeconds};
+
+use log::info;
+
+const TEST_STR: &[u8] = b"TEST SPI TESTING, TESTING, TESTING";
+
+#[entry]
+fn main() -> ! {
+    utilities::logger::init();
+    let cp = cortex_m::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Constrain and Freeze power
+    info!("Setup PWR...                  ");
+    let pwr = dp.PWR.constrain();
+    let pwrcfg = pwr.freeze();
+
+    // Constrain and Freeze clock
+    info!("Setup RCC...                  ");
+    let rcc = dp.RCC.constrain();
+    let ccdr = rcc
+        .sys_ck(192.MHz())
+        .pll1_q_ck(64.MHz())
+        .freeze(pwrcfg, &dp.SBS);
+
+    // Acquire the GPIOB peripheral. This also enables the clock for
+    // GPIOB in the RCC register.
+    let gpiob = dp.GPIOB.split(ccdr.peripheral.GPIOB);
+
+    let sck = gpiob.pb13.into_alternate();
+    let miso = gpiob.pb14.into_alternate();
+    let mosi = gpiob.pb15.into_alternate();
+
+    info!("");
+    info!("stm32h5xx-hal example - SPI");
+    info!("");
+
+    // Initialise the SPI peripheral.
+    let mut spi = dp.SPI2.spi(
+        (sck, miso, mosi),
+        spi::MODE_0,
+        1.MHz(),
+        ccdr.peripheral.SPI2,
+        &ccdr.clocks,
+    );
+
+    // Write short fixed data
+    spi.write(&[0x11u8]).unwrap();
+    spi.write(&[0x11u8, 0x22, 0x33]).unwrap();
+
+    info!("Transfer starting");
+    let mut delay = Delay::new(cp.SYST, &ccdr.clocks);
+    let duration = MilliSeconds::secs(1).to_millis();
+    // Echo what is received on the SPI
+    let write = TEST_STR;
+    let read = &mut [0u8; TEST_STR.len()];
+    loop {
+        spi.transfer(read, write).unwrap();
+        delay.delay_ms(duration);
+    }
+}

--- a/examples/spi_send_frames.rs
+++ b/examples/spi_send_frames.rs
@@ -1,0 +1,93 @@
+//! This example shows off the FrameTransaction mode of hardware chip select functionality.
+//!
+//! For more docs, see https://docs.rs/stm32h7xx-hal/latest/stm32h7xx_hal/spi/index.html
+//!
+
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use cortex_m_rt::entry;
+use cortex_m_semihosting::debug;
+use embedded_hal::spi::{Operation, SpiDevice};
+mod utilities;
+use spi::Spi;
+use stm32h5xx_hal::{
+    pac,
+    prelude::*,
+    spi::{self, CommunicationMode},
+};
+
+use log::info;
+
+#[entry]
+fn main() -> ! {
+    utilities::logger::init();
+    // let cp = cortex_m::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Constrain and Freeze power
+    info!("Setup PWR...                  ");
+    let pwr = dp.PWR.constrain();
+    let pwrcfg = pwr.freeze();
+
+    // Constrain and Freeze clock
+    info!("Setup RCC...                  ");
+    let rcc = dp.RCC.constrain();
+    let ccdr = rcc
+        .sys_ck(192.MHz())
+        .pll1_q_ck(64.MHz())
+        .freeze(pwrcfg, &dp.SBS);
+
+    // Acquire the GPIOB peripheral. This also enables the clock for
+    // GPIOB in the RCC register.
+    let gpiob = dp.GPIOB.split(ccdr.peripheral.GPIOB);
+
+    let sck = gpiob.pb13.into_alternate();
+    let miso = gpiob.pb14.into_alternate();
+    let mosi = gpiob.pb15.into_alternate();
+    // Because we want to use the hardware chip select, we need to provide that too
+    let hcs = gpiob.pb4.into_alternate();
+
+    info!("");
+    info!("stm32h5xx-hal example - SPI Frame Transactions");
+    info!("");
+
+    // Initialise the SPI peripheral.
+    let mut spi: Spi<_, u8> = dp.SPI2.spi(
+        // Give ownership of the pins
+        (sck, miso, mosi, hcs),
+        // Create a config with the hardware chip select given
+        spi::Config::new(spi::MODE_0)
+            // Put 1 us idle time between every word sent
+            .inter_word_delay(0.000001)
+            // Specify that we use the hardware cs
+            .hardware_cs(spi::HardwareCS {
+                // See the docs of the HardwareCSMode to see what the different modes do
+                mode: spi::HardwareCSMode::FrameTransaction,
+                // Put 1 us between the CS being asserted and the first clock
+                assertion_delay: 0.000001,
+                // Our CS should be high when not active and low when asserted
+                polarity: spi::Polarity::IdleHigh,
+            })
+            .communication_mode(CommunicationMode::SimplexTransmitter),
+        1.MHz(),
+        ccdr.peripheral.SPI2,
+        &ccdr.clocks,
+    );
+
+    spi.write(&[0, 1, 2]).unwrap();
+    spi.write(&[0, 1, 2, 3, 4, 5, 6]).unwrap();
+
+    // Compose multiple operations into a single compound transfer using Operations
+    let mut ops = [
+        Operation::Write(&[0x11u8, 0x22, 0x33]),
+        Operation::Write(&[0x44u8, 0x55, 0x66]),
+    ];
+
+    spi.transaction(&mut ops).unwrap();
+
+    loop {
+        debug::exit(debug::EXIT_SUCCESS);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,9 @@ pub mod icache;
 pub mod delay;
 
 #[cfg(feature = "device-selected")]
+pub mod spi;
+
+#[cfg(feature = "device-selected")]
 mod sealed {
     pub trait Sealed {}
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,6 +6,7 @@ pub use crate::i2c::I2cExt as _stm32h5xx_hal_i2c_I2cExt;
 pub use crate::icache::ICacheExt as _stm32h5xx_hal_icache_ICacheExt;
 pub use crate::pwr::PwrExt as _stm32h5xx_hal_pwr_PwrExt;
 pub use crate::rcc::RccExt as _stm32h5xx_hal_rcc_RccExt;
+pub use crate::spi::SpiExt as _stm32h5xx_hal_spi_SpiExt;
 
 pub use crate::time::U32Ext as _;
 pub use fugit::{ExtU32 as _, RateExtU32 as _};

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,0 +1,1008 @@
+//! Serial Peripheral Interface (SPI)
+//!
+//! This module provides functionality for SPI as both a Master. It
+//! supports full-duplex, half duplex, simplex transmitter and simplex receiver
+//! modes.
+//!
+//! It supports both blocking and non-blocking usage. For blocking usage
+//! as a Master `Spi` implements the [embedded-hal][embedded-hal] traits ([`SpiBus`][spi_bus]
+//! and [`SpiDevice`][spi_device]). The driver also provides a
+//! [NonBlocking](nonblocking::NonBlocking) trait that defines the non-blocking API. This must be
+//! explicitly used to access the non-blocking API.
+//!
+//! # Usage
+//!
+//! ## Initialization
+//! In the simplest case, SPI can be initialised from the device peripheral
+//! and the GPIO pins.
+//!
+//! ```
+//! use stm32h5xx_hal::spi;
+//!
+//! let dp = ...;                   // Device peripherals
+//! let (sck, miso, mosi) = ...;    // GPIO pins
+//!
+//! let spi = dp.SPI1.spi((sck, miso, mosi), spi::MODE_0, 1.MHz(), ccdr.peripheral.SPI1, &ccdr.clocks);
+//! ```
+//!
+//! The GPIO pins should be supplied as a tuple in the following order:
+//!
+//! - Serial Clock (SCK)
+//! - Master In Slave Out (MISO)
+//! - Master Out Slave In (MOSI)
+//!
+//! If one of the pins is not required, explicitly pass one of the
+//! filler types instead:
+//!
+//! ```
+//! let spi = dp.SPI1.spi((sck, spi::NoMiso, mosi), spi::MODE_0, 1.MHz(), ccdr.peripheral.SPI1, &ccdr.clocks);
+//! ```
+//!
+//! To use hardware control of CS pins, additionally provide a CS pin during
+//! initialization, and specify hardware CS mode in the config struct:
+//!
+//! ```
+//! use stm32h5xx_hal::spi;
+//!
+//! let dp = ...;                       // Device peripherals
+//! let (sck, miso, mosi, cs) = ...;    // GPIO pins
+//!
+//! let spi = dp.SPI1.spi(
+//!     (sck, miso, mosi, cs),
+//!     spi::Config::new(spi::MODE_0)
+//!         .hardware_cs(spi::HardwareCSMode::FrameTransaction),
+//!     1.MHz(),
+//!     ccdr.peripheral.SPI1,
+//!     &ccdr.clocks);
+//!```
+//!
+//! ## Blocking API
+//! Use the (`SpiBus`)[spi_bus] or (`SpiDevice`)[spi_device] (with hardware control of CS) APIs provided by
+//! [embedded-hal](embedded-hal):
+//!
+//! ```
+//! use stm32h5xx_hal::spi;
+//! use embedded-hal::spi::SpiBus;
+//!
+//! let dp = ...;                   // Device peripherals
+//! let (sck, miso, mosi) = ...;    // GPIO pins
+//!
+//! let spi = dp.SPI1.spi((sck, miso, mosi), spi::MODE_0, 1.MHz(), ccdr.peripheral.SPI1, &ccdr.clocks);
+//!
+//! // Transmit only
+//! spi.write(&[0x11u8, 0x22, 0x33])?;
+//!
+//! // Receive only
+//! let read = &mut [0u8; 3];
+//! spi.read(read)?;
+//!
+//! // Full duplex simultaneous transmit & receive
+//! spi.transfer(read, &[0x11u8, 0x22, 0x33])?;
+//! ```
+//!
+//! ## Non-blocking API
+//! To use the non-blocking API, the [`nonblocking::NonBlocking`] trait must be used. Then,
+//! transactions need to be started via one of the start_nonblocking_XXX methods. This will return
+//! a [`transaction::Transaction`] type that can be passed to
+//! [`nonblocking::NonBlocking::transfer_nonblocking()`].
+//!
+//! ```
+//! use stm32h5xx_hal::spi::{self, nonblocking::NonBlocking};
+//!
+//! let dp = ...;                   // Device peripherals
+//! let (sck, miso, mosi) = ...;    // GPIO pins
+//!
+//! let mut spi = dp.SPI1.spi((sck, miso, mosi), spi::MODE_0, 1.MHz(), ccdr.peripheral.SPI1, &ccdr.clocks);
+//!
+//! let words = [0x11u8, 0x22, 0x33];
+//! let mut write = spi.start_nonblocking_write(&words)?;
+//!
+//! while let Some(t) = spi.transfer_nonblocking(write)? {
+//!     write = t;
+//! }
+//! ```
+//!
+//! ## Clocks
+//!
+//! The bitrate calculation is based upon the clock currently assigned
+//! in the RCC CCIP register. The default assignments are:
+//!
+//! - SPI1, SPI2, SPI3: PLL1Q
+//! - SPI4, SPI6: PCLK2
+//! - SPI5: PCLK3
+//!
+//! ## Word Sizes
+//!
+//! The word size used by the SPI controller must be indicated to the compiler.
+//! This can be done either using an explicit type annotation, or with a type
+//! hint. The supported word sizes are 8, 16 or 32 bits (u8, u16, u32). However,
+//! 32-bit access are not supported by all peripherals.
+//!
+//! For example, an explict type annotation:
+//! ```
+//! let _: spi:Spi<_, u8> = dp.SPI1.spi((sck, spi::NoMiso, mosi), spi::MODE_0, 1.MHz(), ccdr.peripheral.SPI1, &ccdr.clocks);
+//! ```
+//!
+//!
+//! # Examples
+//!
+//! - [SPI Master](https://github.com/stm32-rs/stm32h5xx-hal/blob/master/examples/spi.rs)
+//! - [SPI Master with Frame Transactions](https://github.com/stm32-rs/stm32h5xx-hal/blob/master/examples/spi_send_frames.rs)
+//!
+//! [embedded_hal]: https://docs.rs/embedded-hal/1.0.0-rc.1/embedded_hal/spi/index.html
+//! [spi_bus]: https://docs.rs/embedded-hal/1.0.0-rc.1/embedded_hal/spi/trait.SpiBus.html
+//! [spi_device]: https://docs.rs/embedded-hal/1.0.0-rc.1/embedded_hal/spi/trait.SpiDevice.html
+
+use core::cell::UnsafeCell;
+use core::marker::PhantomData;
+use core::ops::Deref;
+use core::ptr;
+
+pub use embedded_hal::spi::{
+    Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3,
+};
+
+use crate::rcc::{CoreClocks, ResetEnable};
+use crate::stm32::spi1;
+
+use crate::time::Hertz;
+use spi1::{cfg1::MBR, cfg2::LSBFRST, cfg2::SSIOP};
+
+mod config;
+mod hal;
+pub mod nonblocking;
+mod spi_def;
+mod transaction;
+
+pub use config::{
+    CommunicationMode, Config, Endianness, HardwareCS, HardwareCSMode,
+};
+
+use transaction::Op;
+pub use transaction::{Read, Transaction, Transfer, TransferInplace, Write};
+
+/// SPI error
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum Error {
+    /// Overrun occurred
+    Overrun,
+    /// Underrun occurred
+    Underrun,
+    /// Mode fault occurred
+    ModeFault,
+    /// CRC error
+    Crc,
+    /// Calling this method is not valid in this state
+    TransferAlreadyComplete,
+    /// Can't start a transaction because one is already started
+    TransactionAlreadyStarted,
+    /// A buffer is too big to be processed
+    BufferTooBig { max_size: usize },
+    /// Caller makes invalid call (e.g. write in SimplexReceiver mode, or read in
+    /// SimplexTransmitter)
+    InvalidOperation,
+}
+
+pub trait Pins<SPI> {
+    /// States whether or not the Hardware Chip Select is present in this set of pins
+    const HCS_PRESENT: bool;
+}
+
+pub trait PinSck<SPI> {}
+
+pub trait PinMiso<SPI> {}
+
+pub trait PinMosi<SPI> {}
+
+pub trait PinHCS<SPI> {}
+
+impl<SPI, SCK, MISO, MOSI> Pins<SPI> for (SCK, MISO, MOSI)
+where
+    SCK: PinSck<SPI>,
+    MISO: PinMiso<SPI>,
+    MOSI: PinMosi<SPI>,
+{
+    const HCS_PRESENT: bool = false;
+}
+
+impl<SPI, SCK, MISO, MOSI, HCS> Pins<SPI> for (SCK, MISO, MOSI, HCS)
+where
+    SCK: PinSck<SPI>,
+    MISO: PinMiso<SPI>,
+    MOSI: PinMosi<SPI>,
+    HCS: PinHCS<SPI>,
+{
+    const HCS_PRESENT: bool = true;
+}
+
+/// A filler type for when the SCK pin is unnecessary
+pub struct NoSck;
+
+/// A filler type for when the Miso pin is unnecessary
+pub struct NoMiso;
+
+/// A filler type for when the Mosi pin is unnecessary
+pub struct NoMosi;
+
+#[derive(Debug)]
+pub struct Inner<SPI, W: Word> {
+    spi: SPI,
+    _word: PhantomData<W>,
+}
+
+/// Spi in Master mode
+#[derive(Debug)]
+pub struct Spi<SPI, W: Word = u8> {
+    inner: Inner<SPI, W>,
+    _word: PhantomData<W>,
+}
+
+// Implemented by all SPI instances
+pub trait Instance:
+    crate::Sealed + Deref<Target = spi1::RegisterBlock> + Sized
+{
+    type Rec: ResetEnable;
+
+    #[doc(hidden)]
+    fn ptr() -> *const spi1::RegisterBlock;
+
+    #[doc(hidden)]
+    fn clock(clocks: &CoreClocks) -> Hertz;
+
+    #[doc(hidden)]
+    fn rec() -> Self::Rec;
+}
+
+pub trait Word: Copy + Default + 'static + crate::Sealed {
+    const BITS: u8;
+}
+
+macro_rules! word {
+    ($type:ty) => {
+        impl Word for $type {
+            const BITS: u8 = <$type>::BITS as u8;
+        }
+        impl crate::Sealed for $type {}
+    };
+}
+
+word!(u32);
+word!(u16);
+word!(u8);
+
+/// Marker trait to indicate what word sizes each SPI peripheral supports
+pub trait SupportedWordSize<W>: crate::Sealed {}
+
+pub trait SpiExt<SPI: Instance + SupportedWordSize<W>, W: Word = u8> {
+    fn spi<PINS, CONFIG>(
+        self,
+        _pins: PINS,
+        config: CONFIG,
+        freq: Hertz,
+        rec: SPI::Rec,
+        clocks: &CoreClocks,
+    ) -> Spi<SPI, W>
+    where
+        PINS: Pins<SPI>,
+        CONFIG: Into<Config>;
+
+    fn spi_unchecked<CONFIG>(
+        self,
+        config: CONFIG,
+        freq: Hertz,
+        rec: SPI::Rec,
+        clocks: &CoreClocks,
+    ) -> Spi<SPI, W>
+    where
+        CONFIG: Into<Config>;
+}
+
+impl<SPI: Instance + SupportedWordSize<W>, W: Word> SpiExt<SPI, W> for SPI {
+    fn spi<PINS, CONFIG>(
+        self,
+        _pins: PINS,
+        config: CONFIG,
+        freq: Hertz,
+        rec: SPI::Rec,
+        clocks: &CoreClocks,
+    ) -> Spi<SPI, W>
+    where
+        PINS: Pins<SPI>,
+        CONFIG: Into<Config>,
+    {
+        let config = config.into();
+        assert_eq!(
+            config.hardware_cs.enabled(),
+            PINS::HCS_PRESENT,
+            "If the hardware cs is enabled in the config, an HCS pin must be present in the given pins"
+        );
+        Spi::<SPI, W>::new(self, config, freq, rec, clocks)
+    }
+
+    fn spi_unchecked<CONFIG>(
+        self,
+        config: CONFIG,
+        freq: Hertz,
+        rec: SPI::Rec,
+        clocks: &CoreClocks,
+    ) -> Spi<SPI, W>
+    where
+        CONFIG: Into<Config>,
+    {
+        Spi::<SPI, W>::new(self, config, freq, rec, clocks)
+    }
+}
+
+fn calc_mbr(spi_ker_ck: u32, spi_freq: u32) -> MBR {
+    match spi_ker_ck.div_ceil(spi_freq) {
+        1..=2 => MBR::Div2,
+        3..=4 => MBR::Div4,
+        5..=8 => MBR::Div8,
+        9..=16 => MBR::Div16,
+        17..=32 => MBR::Div32,
+        33..=64 => MBR::Div64,
+        65..=128 => MBR::Div128,
+        _ => MBR::Div256,
+    }
+}
+
+impl<SPI: Instance, W: Word> Spi<SPI, W> {
+    fn new(
+        spi: SPI,
+        config: impl Into<Config>,
+        freq: Hertz,
+        rec: SPI::Rec,
+        clocks: &CoreClocks,
+    ) -> Self {
+        let config: Config = config.into();
+        rec.enable();
+
+        let spi = Spi {
+            inner: Inner::new(spi),
+            _word: PhantomData,
+        };
+        spi.init(config, freq, SPI::clock(clocks))
+    }
+
+    fn spi(&mut self) -> &mut SPI {
+        &mut self.inner.spi
+    }
+
+    fn init(mut self, config: Config, freq: Hertz, clock: Hertz) -> Self {
+        let spi_freq = freq.raw();
+        let spi_ker_ck = clock.raw();
+        let mbr = calc_mbr(spi_ker_ck, spi_freq);
+        self.spi().cfg1().modify(|_, w| {
+            w.mbr()
+                .variant(mbr) // master baud rate
+                .dsize()
+                .set(W::BITS - 1)
+        });
+
+        // Select master mode
+        self.spi().cr1().write(|w| w.ssi().slave_not_selected());
+
+        // Calculate the CS->transaction cycle delay bits.
+        let (assertion_delay, inter_word_delay) = {
+            let mut assertion_delay: u32 =
+                (config.hardware_cs.assertion_delay * spi_freq as f32) as u32;
+            let mut inter_word_delay: u32 =
+                (config.inter_word_delay * spi_freq as f32) as u32;
+
+            // If a delay is specified as non-zero, add 1 to the delay cycles
+            // before truncation to an integer to ensure that we have at least as
+            // many cycles as required.
+            if config.hardware_cs.assertion_delay > 0.0_f32 {
+                assertion_delay += 1;
+            }
+            if config.inter_word_delay > 0.0_f32 {
+                inter_word_delay += 1;
+            }
+
+            // If CS suspends while data is inactive, we also require an
+            // "inter-data" delay.
+            if matches!(
+                config.hardware_cs.mode,
+                HardwareCSMode::WordTransaction
+            ) {
+                inter_word_delay = inter_word_delay.max(1);
+            }
+
+            (
+                assertion_delay.min(0xF) as u8,
+                inter_word_delay.min(0xF) as u8,
+            )
+        };
+
+        let cs_polarity = match config.hardware_cs.polarity {
+            Polarity::IdleHigh => SSIOP::ActiveLow,
+            Polarity::IdleLow => SSIOP::ActiveHigh,
+        };
+
+        let endianness = match config.endianness {
+            Endianness::LsbFirst => LSBFRST::Lsbfirst,
+            Endianness::MsbFirst => LSBFRST::Msbfirst,
+        };
+
+        self.spi().cfg2().write(|w| {
+            w.cpha()
+                .bit(config.mode.phase == Phase::CaptureOnSecondTransition)
+                .cpol()
+                .bit(config.mode.polarity == Polarity::IdleHigh)
+                .master()
+                .master()
+                .lsbfrst()
+                .variant(endianness)
+                .ssom()
+                .bit(config.hardware_cs.interleaved_cs())
+                .ssm()
+                .bit(!config.hardware_cs.enabled())
+                .ssoe()
+                .bit(config.hardware_cs.enabled())
+                .mssi()
+                .set(assertion_delay)
+                .midi()
+                .set(inter_word_delay)
+                .ioswp()
+                .bit(config.swap_miso_mosi)
+                .comm()
+                .variant(config.communication_mode.into())
+                .ssiop()
+                .variant(cs_polarity)
+        });
+
+        self
+    }
+}
+
+macro_rules! check_status_error {
+    ($sr:expr) => {
+        if $sr.ovr().is_overrun() {
+            Err(Error::Overrun)
+        } else if $sr.udr().is_underrun() {
+            Err(Error::Underrun)
+        } else if $sr.modf().is_fault() {
+            Err(Error::ModeFault)
+        } else if $sr.crce().is_error() {
+            Err(Error::Crc)
+        } else {
+            Ok(())
+        }
+    };
+}
+
+impl<SPI: Instance, W: Word> Inner<SPI, W> {
+    fn new(spi: SPI) -> Self {
+        Self {
+            spi,
+            _word: PhantomData,
+        }
+    }
+
+    /// Enable SPI
+    fn enable(&mut self) {
+        self.spi.cr1().modify(|_, w| w.spe().enabled());
+    }
+
+    /// Enable SPI
+    fn disable(&mut self) {
+        self.spi.cr1().modify(|_, w| w.spe().disabled());
+    }
+
+    /// Read the SPI communication mode
+    fn communication_mode(&self) -> CommunicationMode {
+        self.spi.cfg2().read().comm().variant().into()
+    }
+
+    /// Determine if SPI is a transmitter
+    fn is_transmitter(&self) -> bool {
+        match self.communication_mode() {
+            CommunicationMode::FullDuplex => true,
+            CommunicationMode::HalfDuplex => self.is_half_duplex_transmitter(),
+            CommunicationMode::SimplexTransmitter => true,
+            CommunicationMode::SimplexReceiver => false,
+        }
+    }
+
+    /// Set SPI to transmit mode in half duplex operation
+    /// Only valid in half duplex operation. This is provided for non-blocking calls to be able to
+    /// change direction of communication. Blocking calls already handle this
+    pub fn set_dir_transmitter(&self) {
+        assert!(matches!(
+            self.communication_mode(),
+            CommunicationMode::HalfDuplex
+        ));
+
+        self.spi.cr1().modify(|_, w| w.hddir().transmitter());
+    }
+
+    /// Set SPI to receive mode in half duplex operation
+    /// Only valid in half duplex operation. This is provided for non-blocking calls to be able to
+    /// change direction of communication. Blocking calls already handle this
+    pub fn set_dir_receiver(&self) {
+        assert!(matches!(
+            self.communication_mode(),
+            CommunicationMode::HalfDuplex
+        ));
+
+        self.spi.cr1().modify(|_, w| w.hddir().receiver());
+    }
+
+    fn is_half_duplex_transmitter(&self) -> bool {
+        self.spi.cr1().read().hddir().is_transmitter()
+    }
+
+    /// Set the word size for a transaction. Can only be changed when the peripheral is disabled
+    #[inline(always)]
+    fn set_word_size(&self, word_size: usize) {
+        // Do not allow a word size greater than W, and ensure that it is greater than the minimum
+        // word size for the peripheral
+        assert!(word_size <= (W::BITS as usize) && word_size >= 4);
+        self.spi
+            .cfg1()
+            .modify(|_, w| w.dsize().set((word_size as u8) - 1));
+    }
+
+    /// Clears the MODF flag, which indicates that a
+    /// mode fault has occurred.
+    #[inline(always)]
+    fn clear_modf(&mut self) {
+        self.spi.ifcr().write(|w| w.modfc().clear());
+        let _ = self.spi.sr().read();
+        let _ = self.spi.sr().read();
+    }
+
+    /// Read a single word from the receive data register
+    #[inline(always)]
+    fn read_data_reg(&mut self) -> W {
+        // NOTE(read_volatile) read only 1 byte (the svd2rust API only allows
+        // reading a half-word)
+        unsafe { ptr::read_volatile(self.spi.rxdr() as *const _ as *const W) }
+    }
+
+    #[inline(always)]
+    fn write_data_reg(&mut self, data: W) {
+        // NOTE(write_volatile/read_volatile) write/read only 1 word
+        unsafe {
+            let txdr = self.spi.txdr() as *const _ as *const UnsafeCell<W>;
+            ptr::write_volatile(UnsafeCell::raw_get(txdr), data);
+        }
+    }
+
+    #[inline(always)]
+    fn read_if_ready(&mut self, word: &mut W) -> Result<bool, Error> {
+        let sr = self.spi.sr().read();
+
+        check_status_error!(sr)?;
+
+        if sr.rxp().is_not_empty() {
+            *word = self.read_data_reg();
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    #[inline(always)]
+    fn write_if_ready(&mut self, word: W) -> Result<bool, Error> {
+        let sr = self.spi.sr().read();
+
+        check_status_error!(sr)?;
+
+        if sr.txp().is_not_full() {
+            self.write_data_reg(word);
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Fill the TX FIFO. Will write to the TX fifo until it is full. The
+    /// amount of words written are returned wrapped in the Ok value.
+    #[inline(always)]
+    fn fill_tx_fifo(&mut self, words: &[W]) -> Result<usize, Error> {
+        for (i, word) in words.iter().enumerate() {
+            if !self.write_if_ready(*word)? {
+                return Ok(i);
+            }
+        }
+        Ok(words.len())
+    }
+
+    /// Flush the TX Fifo. Attempts to write `len` zeroes to the TX FIFO.
+    /// Returns the number written, wrapped in an Ok result, unless an error
+    /// occurs.
+    #[inline(always)]
+    fn flush_tx_fifo(&mut self, len: usize) -> Result<usize, Error> {
+        for i in 0..len {
+            if !self.write_if_ready(W::default())? {
+                return Ok(i);
+            }
+        }
+        Ok(len)
+    }
+
+    /// Reads as many words as are available in the RX FIFO.  The amount of
+    /// words written are returned wrapped in the Ok value, unless an error
+    /// occurs.
+    #[inline(always)]
+    fn drain_rx_fifo(&mut self, words: &mut [W]) -> Result<usize, Error> {
+        for (i, word) in words.iter_mut().enumerate() {
+            if !self.read_if_ready(word)? {
+                return Ok(i);
+            }
+        }
+        Ok(words.len())
+    }
+
+    /// Flush the RX Fifo. Attempts to read `len` bytes from the RX FIFO.
+    /// Returns the number read, wrapped in an Ok result, unless an error
+    /// occurs.
+    #[inline(always)]
+    fn discard_rx_fifo(&mut self, len: usize) -> Result<usize, Error> {
+        for i in 0..len {
+            let mut dummy = W::default();
+            if !self.read_if_ready(&mut dummy)? {
+                return Ok(i);
+            }
+        }
+        Ok(len)
+    }
+
+    /// Write operation for a partial transaction. For use in multi-operation transactions via
+    /// embedded-hal's SpiDevice trait.
+    fn write_partial(&mut self, words: &[W]) -> Result<(), Error> {
+        let mut write = Transaction::<Write<W>, W>::write(words);
+        while !write.is_complete() {
+            self.transfer_words_nonblocking(&mut write)?;
+        }
+
+        Ok(())
+    }
+
+    /// Read operation for a partial transaction. For use in multi-operation transactions via
+    /// embedded-hal's SpiDevice trait.
+    fn read_partial(&mut self, words: &mut [W]) -> Result<(), Error> {
+        let mut read = Transaction::<Read<W>, W>::read(words);
+        while !read.is_complete() {
+            self.transfer_words_nonblocking(&mut read)?;
+        }
+
+        Ok(())
+    }
+
+    /// Duplex transfer for a partial transaction. For use in multi-operation transactions via
+    /// embedded-hal's SpiDevice trait.
+    fn transfer_partial(
+        &mut self,
+        read: &mut [W],
+        write: &[W],
+    ) -> Result<(), Error> {
+        let mut transfer = Transaction::<Transfer<W>, W>::transfer(write, read);
+        while !transfer.is_complete() {
+            self.transfer_words_nonblocking(&mut transfer)?;
+        }
+
+        Ok(())
+    }
+
+    /// Duplex transfer in place for a partial transaction. For use in multi-operation transactions
+    /// via embedded-hal's SpiDevice trait.
+    fn transfer_inplace_partial(
+        &mut self,
+        words: &mut [W],
+    ) -> Result<(), Error> {
+        let mut transfer =
+            Transaction::<TransferInplace<W>, W>::transfer_inplace(words);
+        while !transfer.is_complete() {
+            self.transfer_words_nonblocking(&mut transfer)?;
+        }
+        Ok(())
+    }
+
+    fn write_words_nonblocking<OP: Op<W>>(
+        &mut self,
+        transaction: &mut Transaction<OP, W>,
+    ) -> Result<(), Error> {
+        // Don't attempt to write out more than the size of the transaction
+        let count = self.fill_tx_fifo(transaction.write_buf())?;
+        transaction.advance_write_idx(count);
+        Ok(())
+    }
+
+    fn read_words_nonblocking<OP: Op<W>>(
+        &mut self,
+        transaction: &mut Transaction<OP, W>,
+    ) -> Result<(), Error> {
+        let count = self.drain_rx_fifo(transaction.read_buf())?;
+        transaction.advance_read_idx(count);
+        Ok(())
+    }
+
+    /// Transfers words in a non-blocking manner. This function drives all SPI read/write/transfer
+    /// operations in this driver.
+    ///
+    /// This will write data to the TX FIFO if there is data to write, and read data from the RX
+    /// FIFO if there is data to read. If there is data to read, but not to write (ie. read length
+    /// is greater than write length) then it will write dummy bytes (zeroes) to the TX FIFO to
+    /// clock in the remaining read data. If there is data to write, but not to read, the contents
+    /// of the RX FIFO will be discarded.
+    #[inline(always)]
+    fn transfer_words_nonblocking<OP: Op<W>>(
+        &mut self,
+        transaction: &mut Transaction<OP, W>,
+    ) -> Result<(), Error> {
+        if !transaction.is_write_complete() {
+            self.write_words_nonblocking(transaction)?;
+        }
+
+        // Keep writing to SPI if data to read is longer than data to write
+        let flush_remainder = transaction.tx_flush_remainder();
+        if transaction.is_write_complete() && flush_remainder > 0 {
+            let count = self.flush_tx_fifo(flush_remainder)?;
+            transaction.advance_write_idx(count)
+        }
+
+        if !transaction.is_read_complete() {
+            self.read_words_nonblocking(transaction)?;
+        }
+
+        // Keep emptying Rx FIFO if data to write is longer than data to read
+        let discard_remainder = transaction.rx_remainder_to_discard();
+        if transaction.is_read_complete() && discard_remainder > 0 {
+            let count = self.discard_rx_fifo(discard_remainder)?;
+            transaction.advance_read_idx(count);
+        }
+
+        Ok(())
+    }
+}
+
+impl<SPI: Instance, W: Word> Spi<SPI, W> {
+    /// Set the word size for a transaction. Can only be changed when the peripheral is disabled
+    /// Must be less than or equal to the maximum size denoted by the const generic size parameter
+    /// (W)
+    pub fn set_word_size(&mut self, word_size: usize) {
+        self.inner.set_word_size(word_size);
+    }
+
+    /// Sets up a frame transaction with the given amount of data words.
+    ///
+    /// If this is called when a transaction has already started,
+    /// then an error is returned with [Error::TransactionAlreadyStarted].
+    fn setup_transaction(&mut self, length: usize) {
+        assert!(
+            length <= u16::MAX as usize,
+            "Buffer too big! Max transaction size is {}",
+            u16::MAX
+        );
+
+        self.spi().cr2().write(|w| w.tsize().set(length as u16));
+
+        // Re-enable
+        self.inner.clear_modf();
+        self.inner.enable();
+        self.spi().cr1().modify(|_, w| w.cstart().started());
+    }
+
+    /// Checks if the current transaction is complete and disables the
+    /// peripheral if it is, returning true. If it isn't, returns false.
+    fn end_transaction_if_done(&mut self) -> bool {
+        let sr = self.spi().sr().read();
+        let is_complete = if self.inner.is_transmitter() {
+            sr.eot().is_completed() && sr.txc().is_completed()
+        } else {
+            sr.eot().is_completed()
+        };
+
+        if !is_complete {
+            return false;
+        }
+
+        // Errata ES0561 Rev 3 2.13.2: Disabling the peripheral can cut short the last clock pulse
+        // which can cause transmission failures. This spin loop causes a long enough delay for most
+        // clock frequencies such that the last clock is output correctly.
+        for _i in 0..30 {
+            cortex_m::asm::nop()
+        }
+
+        self.spi()
+            .ifcr()
+            .write(|w| w.txtfc().clear().eotc().clear().suspc().clear());
+
+        self.inner.disable();
+        true
+    }
+
+    /// Ends the current transaction. Waits for all data to be transmitted.
+    /// This must always be called when all data has been sent to
+    /// properly terminate the transaction and reset the SPI peripheral.
+    fn end_transaction(&mut self) {
+        // Result is only () or WouldBlock. Discard result.
+        while !self.end_transaction_if_done() {}
+    }
+
+    fn abort_transaction(&mut self) {
+        self.inner.disable();
+    }
+
+    /// Deconstructs the SPI peripheral and returns the component parts.
+    pub fn free(self) -> SPI {
+        self.inner.spi
+    }
+
+    pub fn inner(&self) -> &SPI {
+        &self.inner.spi
+    }
+
+    pub fn inner_mut(&mut self) -> &mut SPI {
+        &mut self.inner.spi
+    }
+}
+
+/// Non-blocking SPI operations
+impl<SPI: Instance, W: Word> Spi<SPI, W> {
+    fn transfer_nonblocking_internal<OP: Op<W>>(
+        &mut self,
+        mut transaction: Transaction<OP, W>,
+    ) -> Result<Option<Transaction<OP, W>>, Error> {
+        self.inner
+            .transfer_words_nonblocking(&mut transaction)
+            .inspect_err(|_| self.abort_transaction())?;
+
+        if transaction.is_complete() && self.end_transaction_if_done() {
+            Ok(None)
+        } else {
+            Ok(Some(transaction))
+        }
+    }
+
+    fn start_write<'a>(
+        &mut self,
+        words: &'a [W],
+    ) -> Result<Transaction<Write<'a, W>, W>, Error> {
+        assert!(
+            !words.is_empty(),
+            "Write buffer should not be non-zero length"
+        );
+        let communication_mode = self.inner.communication_mode();
+        if communication_mode == CommunicationMode::SimplexReceiver {
+            return Err(Error::InvalidOperation);
+        }
+
+        if communication_mode == CommunicationMode::HalfDuplex {
+            self.inner.set_dir_transmitter();
+        }
+
+        self.setup_transaction(words.len());
+
+        Ok(Transaction::<Write<'a, W>, W>::write(words))
+    }
+
+    fn start_read<'a>(
+        &mut self,
+        buf: &'a mut [W],
+    ) -> Result<Transaction<Read<'a, W>, W>, Error> {
+        assert!(!buf.is_empty(), "Read buffer should not be non-zero length");
+        let communication_mode = self.inner.communication_mode();
+        if communication_mode == CommunicationMode::SimplexTransmitter {
+            return Err(Error::InvalidOperation);
+        }
+
+        if communication_mode == CommunicationMode::HalfDuplex {
+            self.inner.set_dir_receiver();
+        }
+
+        self.setup_transaction(buf.len());
+
+        Ok(Transaction::<Read<'a, W>, W>::read(buf))
+    }
+
+    fn start_transfer<'a>(
+        &mut self,
+        read: &'a mut [W],
+        write: &'a [W],
+    ) -> Result<Transaction<Transfer<'a, W>, W>, Error> {
+        assert!(
+            !read.is_empty() && !write.is_empty(),
+            "Transfer buffers should not be non-zero length"
+        );
+        if self.inner.communication_mode() != CommunicationMode::FullDuplex {
+            return Err(Error::InvalidOperation);
+        }
+
+        self.setup_transaction(core::cmp::max(read.len(), write.len()));
+
+        Ok(Transaction::<Transfer<'a, W>, W>::transfer(write, read))
+    }
+
+    fn start_transfer_inplace<'a>(
+        &mut self,
+        words: &'a mut [W],
+    ) -> Result<Transaction<TransferInplace<'a, W>, W>, Error> {
+        assert!(
+            !words.is_empty(),
+            "Transfer buffer should not be non-zero length"
+        );
+        if self.inner.communication_mode() != CommunicationMode::FullDuplex {
+            return Err(Error::InvalidOperation);
+        }
+
+        self.setup_transaction(words.len());
+
+        Ok(Transaction::<TransferInplace<'a, W>, W>::transfer_inplace(
+            words,
+        ))
+    }
+}
+
+// Blocking SPI operations
+impl<SPI: Instance, W: Word> Spi<SPI, W> {
+    fn transfer_internal<OP: Op<W>>(
+        &mut self,
+        mut transaction: Transaction<OP, W>,
+    ) -> Result<(), Error> {
+        while let Some(t) = self.transfer_nonblocking_internal(transaction)? {
+            transaction = t;
+        }
+        Ok(())
+    }
+
+    /// Write-only transfer
+    fn write(&mut self, words: &[W]) -> Result<(), Error> {
+        if words.is_empty() {
+            return Ok(());
+        }
+
+        let transaction = self.start_write(words)?;
+        self.transfer_internal(transaction)
+    }
+
+    /// Read-only transfer
+    fn read(&mut self, words: &mut [W]) -> Result<(), Error> {
+        if words.is_empty() {
+            return Ok(());
+        }
+        let transaction = self.start_read(words)?;
+        self.transfer_internal(transaction)
+    }
+
+    /// Full duplex transfer
+    fn transfer(&mut self, read: &mut [W], write: &[W]) -> Result<(), Error> {
+        if read.is_empty() && write.is_empty() {
+            return Ok(());
+        }
+
+        let transaction = self.start_transfer(read, write)?;
+        self.transfer_internal(transaction)
+    }
+
+    /// Full duplex transfer with single buffer for transmit and receive
+    fn transfer_inplace(&mut self, words: &mut [W]) -> Result<(), Error> {
+        if words.is_empty() {
+            return Ok(());
+        }
+
+        let transaction = self.start_transfer_inplace(words)?;
+        self.transfer_internal(transaction)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_calc_mbr() {
+        let result = calc_mbr(100_000_000, 50_000_000);
+        assert_eq!(result, MBR::Div2);
+
+        let result = calc_mbr(50_000_000, 1_000_000);
+        assert_eq!(result, MBR::Div64);
+
+        let result = calc_mbr(32_000_000, 1_000_000);
+        assert_eq!(result, MBR::Div32);
+    }
+}

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,8 +1,7 @@
 //! Serial Peripheral Interface (SPI)
 //!
-//! This module provides functionality for SPI as both a Master. It
-//! supports full-duplex, half duplex, simplex transmitter and simplex receiver
-//! modes.
+//! This module provides functionality for SPI as a Master. It supports full-duplex, half duplex,
+//! simplex transmitter and simplex receiver modes.
 //!
 //! It supports both blocking and non-blocking usage. For blocking usage
 //! as a Master `Spi` implements the [embedded-hal][embedded-hal] traits ([`SpiBus`][spi_bus]

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -426,7 +426,9 @@ impl<SPI: Instance, W: Word> Spi<SPI, W> {
         };
 
         self.spi().cfg2().write(|w| {
-            w.cpha()
+            w.afcntr()
+                .controlled()
+                .cpha()
                 .bit(config.mode.phase == Phase::CaptureOnSecondTransition)
                 .cpol()
                 .bit(config.mode.polarity == Polarity::IdleHigh)
@@ -925,7 +927,7 @@ impl<SPI: Instance, W: Word> Spi<SPI, W> {
     ) -> Result<Transaction<Transfer<'a, W>, W>, Error> {
         assert!(
             !read.is_empty() && !write.is_empty(),
-            "Transfer buffers should not be non-zero length"
+            "Transfer buffers should not be of zero length"
         );
         if self.inner.communication_mode() != CommunicationMode::FullDuplex {
             return Err(Error::InvalidOperation);
@@ -942,7 +944,7 @@ impl<SPI: Instance, W: Word> Spi<SPI, W> {
     ) -> Result<Transaction<TransferInplace<'a, W>, W>, Error> {
         assert!(
             !words.is_empty(),
-            "Transfer buffer should not be non-zero length"
+            "Transfer buffer should not be of zero length"
         );
         if self.inner.communication_mode() != CommunicationMode::FullDuplex {
             return Err(Error::InvalidOperation);

--- a/src/spi/config.rs
+++ b/src/spi/config.rs
@@ -131,7 +131,7 @@ impl Config {
         self
     }
 
-    // /// Select endianness is used for data transfers
+    /// Select endianness used for data transfers
     pub fn endianness(mut self, endianness: Endianness) -> Self {
         self.endianness = endianness;
         self

--- a/src/spi/config.rs
+++ b/src/spi/config.rs
@@ -1,0 +1,213 @@
+use crate::stm32::spi1::cfg2::COMM;
+
+use super::{Mode, Polarity};
+
+/// Specifies the communication mode of the SPI interface.
+#[derive(Copy, Clone, PartialEq)]
+pub enum CommunicationMode {
+    /// Both RX and TX are used on separate wires. This is the default communications mode
+    FullDuplex,
+
+    /// RX and TX are used on a single wire.
+    HalfDuplex,
+
+    /// Only the SPI TX functionality is used on a single wire.
+    SimplexTransmitter,
+
+    /// Only the SPI RX functionality is used on a single wire.
+    SimplexReceiver,
+}
+
+impl From<COMM> for CommunicationMode {
+    fn from(value: COMM) -> Self {
+        match value {
+            COMM::Transmitter => CommunicationMode::SimplexTransmitter,
+            COMM::Receiver => CommunicationMode::SimplexReceiver,
+            COMM::FullDuplex => CommunicationMode::FullDuplex,
+            COMM::HalfDuplex => CommunicationMode::HalfDuplex,
+        }
+    }
+}
+
+impl From<CommunicationMode> for COMM {
+    fn from(value: CommunicationMode) -> Self {
+        match value {
+            CommunicationMode::SimplexTransmitter => COMM::Transmitter,
+            CommunicationMode::SimplexReceiver => COMM::Receiver,
+            CommunicationMode::FullDuplex => COMM::FullDuplex,
+            CommunicationMode::HalfDuplex => COMM::HalfDuplex,
+        }
+    }
+}
+
+/// The endianness with which to send the data
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Endianness {
+    /// Least significant bit first
+    LsbFirst,
+    /// Most significant bit first. MSB first is the default SPI behavior.
+    MsbFirst,
+}
+
+/// A structure for specifying SPI configuration.
+///
+/// This structure uses builder semantics to generate the configuration.
+///
+/// `Example`
+/// ```
+/// use stm32h5xx::spi::Mode;
+///
+/// let config = Config::new(Mode::MODE_0)
+///     .manage_cs()
+/// ```
+#[derive(Copy, Clone)]
+pub struct Config {
+    pub(super) mode: Mode,
+    pub(super) swap_miso_mosi: bool,
+    pub(super) hardware_cs: HardwareCS,
+    pub(super) inter_word_delay: f32,
+    pub(super) communication_mode: CommunicationMode,
+    pub(super) endianness: Endianness,
+}
+
+impl Config {
+    /// Create a default configuration for the SPI interface.
+    ///
+    /// Arguments:
+    /// * `mode` - The SPI mode to configure.
+    pub fn new(mode: Mode) -> Self {
+        Config {
+            mode,
+            swap_miso_mosi: false,
+            hardware_cs: HardwareCS {
+                mode: HardwareCSMode::Disabled,
+                assertion_delay: 0.0,
+                polarity: Polarity::IdleHigh,
+            },
+            inter_word_delay: 0.0,
+            communication_mode: CommunicationMode::FullDuplex,
+            endianness: Endianness::MsbFirst,
+        }
+    }
+
+    /// Specify that the SPI MISO/MOSI lines are swapped.
+    ///
+    /// Note:
+    /// * This function updates the HAL peripheral to treat the pin provided in the MISO parameter
+    ///   as the MOSI pin and the pin provided in the MOSI parameter as the MISO pin.
+    #[must_use]
+    pub fn swap_mosi_miso(mut self) -> Self {
+        self.swap_miso_mosi = true;
+        self
+    }
+
+    /// Specify the behaviour of the hardware chip select.
+    ///
+    /// This also affects the way data is sent using [HardwareCSMode].
+    /// By default the hardware cs is disabled.
+    #[must_use]
+    pub fn hardware_cs<CS>(mut self, hardware_cs: CS) -> Self
+    where
+        CS: Into<HardwareCS>,
+    {
+        self.hardware_cs = hardware_cs.into();
+        self
+    }
+
+    /// Specify the time in seconds that should be idled between every data word being sent.
+    ///
+    /// Note:
+    /// * This value is converted to a number of spi peripheral clock ticks and at most 15 of those.
+    #[must_use]
+    pub fn inter_word_delay(mut self, inter_word_delay: f32) -> Self {
+        self.inter_word_delay = inter_word_delay;
+        self
+    }
+
+    /// Select the communication mode of the SPI bus.
+    #[must_use]
+    pub fn communication_mode(mut self, mode: CommunicationMode) -> Self {
+        self.communication_mode = mode;
+        self
+    }
+
+    // /// Select endianness is used for data transfers
+    pub fn endianness(mut self, endianness: Endianness) -> Self {
+        self.endianness = endianness;
+        self
+    }
+}
+
+impl From<Mode> for Config {
+    fn from(mode: Mode) -> Self {
+        Self::new(mode)
+    }
+}
+
+/// Object containing the settings for the hardware chip select pin
+#[derive(Clone, Copy)]
+pub struct HardwareCS {
+    /// The value that determines the behaviour of the hardware chip select pin.
+    pub mode: HardwareCSMode,
+    /// The delay between CS assertion and the beginning of the SPI transaction in seconds.
+    ///
+    /// Note:
+    /// * This value introduces a delay on SCK from the initiation of the transaction. The delay
+    ///   is specified as a number of SCK cycles, so the actual delay may vary.
+    pub assertion_delay: f32,
+    /// The polarity of the CS pin.
+    pub polarity: Polarity,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum HardwareCSMode {
+    /// Handling the CS is left for the user to do in software
+    Disabled,
+    /// The CS will assert and de-assert for each word being sent
+    WordTransaction,
+    /// The CS will assert and only de-assert after the whole frame is sent.
+    ///
+    /// When this mode is active, the blocking embedded hal interface automatically
+    /// sets up the frames so it will be one frame per call.
+    ///
+    /// Note:
+    /// * If using the non-blocking APIs, this mode does require some maintenance. Before sending,
+    ///   you must setup the frame with [Spi::setup_transaction]. After everything has been sent,
+    ///   you must also clean it up with [Spi::end_transaction].
+    FrameTransaction,
+}
+
+impl HardwareCS {
+    pub fn new(mode: HardwareCSMode) -> Self {
+        HardwareCS {
+            mode,
+            assertion_delay: 0.0,
+            polarity: Polarity::IdleHigh,
+        }
+    }
+
+    pub fn assertion_delay(mut self, delay: f32) -> Self {
+        self.assertion_delay = delay;
+        self
+    }
+
+    pub fn polarity(mut self, polarity: Polarity) -> Self {
+        self.polarity = polarity;
+        self
+    }
+
+    pub(super) fn enabled(&self) -> bool {
+        !matches!(self.mode, HardwareCSMode::Disabled)
+    }
+
+    pub(super) fn interleaved_cs(&self) -> bool {
+        matches!(self.mode, HardwareCSMode::WordTransaction)
+    }
+}
+
+impl From<HardwareCSMode> for HardwareCS {
+    fn from(value: HardwareCSMode) -> Self {
+        HardwareCS::new(value)
+    }
+}

--- a/src/spi/hal.rs
+++ b/src/spi/hal.rs
@@ -1,0 +1,120 @@
+use embedded_hal::spi::{
+    Error as HalError, ErrorKind, ErrorType, Operation, SpiBus, SpiDevice,
+};
+
+use super::{Error, Instance, Spi, Word};
+
+impl HalError for Error {
+    fn kind(&self) -> ErrorKind {
+        match self {
+            Error::Overrun => ErrorKind::Overrun,
+            Error::Underrun => ErrorKind::Other,
+            Error::ModeFault => ErrorKind::ModeFault,
+            Error::Crc => ErrorKind::Other,
+            Error::TransferAlreadyComplete => ErrorKind::Other,
+            Error::TransactionAlreadyStarted => ErrorKind::Other,
+            Error::BufferTooBig { max_size: _ } => ErrorKind::Other,
+            Error::InvalidOperation => ErrorKind::Other,
+        }
+    }
+}
+
+impl<SPI, W: Word> ErrorType for Spi<SPI, W> {
+    type Error = Error;
+}
+
+impl<SPI: Instance, W: Word> SpiBus<W> for Spi<SPI, W> {
+    fn read(&mut self, words: &mut [W]) -> Result<(), Self::Error> {
+        Spi::read(self, words)
+    }
+
+    fn write(&mut self, words: &[W]) -> Result<(), Self::Error> {
+        Spi::write(self, words)
+    }
+
+    fn transfer(
+        &mut self,
+        read: &mut [W],
+        write: &[W],
+    ) -> Result<(), Self::Error> {
+        Spi::transfer(self, read, write)
+    }
+
+    fn transfer_in_place(
+        &mut self,
+        words: &mut [W],
+    ) -> Result<(), Self::Error> {
+        Spi::transfer_inplace(self, words)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        // This is handled within each of the above functions
+        Ok(())
+    }
+}
+
+trait OperationExt {
+    fn len(&self) -> usize;
+}
+
+impl<W> OperationExt for Operation<'_, W> {
+    fn len(&self) -> usize {
+        match self {
+            Operation::Read(words) => words.len(),
+            Operation::Write(words) => words.len(),
+            Operation::Transfer(read, write) => {
+                core::cmp::max(read.len(), write.len())
+            }
+            Operation::TransferInPlace(words) => words.len(),
+            Operation::DelayNs(_) => 0,
+        }
+    }
+}
+
+impl<SPI: Instance, W: Word> Spi<SPI, W> {
+    #[inline(always)]
+    fn perform_operation(
+        &mut self,
+        operation: &mut Operation<'_, W>,
+    ) -> Result<(), Error> {
+        match operation {
+            Operation::Read(words) => self.inner.read_partial(words),
+            Operation::Write(words) => self.inner.write_partial(words),
+            Operation::Transfer(read, write) => {
+                self.inner.transfer_partial(read, write)
+            }
+            Operation::TransferInPlace(words) => {
+                self.inner.transfer_inplace_partial(words)
+            }
+            Operation::DelayNs(_) => {
+                unimplemented!()
+            }
+        }
+    }
+}
+
+impl<SPI: Instance, W: Word> SpiDevice<W> for Spi<SPI, W> {
+    fn transaction(
+        &mut self,
+        operations: &mut [Operation<'_, W>],
+    ) -> Result<(), Self::Error> {
+        let len = operations.iter().fold(0, |acc, op| acc + op.len());
+        if len == 0 {
+            return Ok(());
+        }
+        self.setup_transaction(len);
+
+        for operation in operations {
+            match self.perform_operation(operation) {
+                Ok(()) => {}
+                Err(error) => {
+                    self.abort_transaction();
+                    return Err(error);
+                }
+            }
+        }
+
+        self.end_transaction();
+        Ok(())
+    }
+}

--- a/src/spi/nonblocking.rs
+++ b/src/spi/nonblocking.rs
@@ -1,0 +1,88 @@
+use super::{
+    Error, Instance, Op, Read, Spi, Transaction, Transfer, TransferInplace,
+    Word, Write,
+};
+
+/// Trait that provides non-blocking SPI operations.
+pub trait NonBlocking<W: Word> {
+    /// Start a non-blocking read operation. This will return a [`Transaction`] that can be processed
+    /// by calling [`NonBlocking::transfer_nonblocking`] until it completes.
+    fn start_nonblocking_read<'a>(
+        &mut self,
+        buf: &'a mut [W],
+    ) -> Result<Transaction<Read<'a, W>, W>, Error>;
+
+    /// Start a non-blocking write operation. This will return a [`Transaction`] that can be processed
+    /// by calling [`NonBlocking::transfer_nonblocking`] until it completes.
+    fn start_nonblocking_write<'a>(
+        &mut self,
+        words: &'a [W],
+    ) -> Result<Transaction<Write<'a, W>, W>, Error>;
+
+    /// Start a non-blocking full duplex transfer operation. This will return a [`Transaction`] that
+    /// can be processed by calling [`NonBlocking::transfer_nonblocking`] until it completes.
+    fn start_nonblocking_duplex_transfer<'a>(
+        &mut self,
+        read: &'a mut [W],
+        write: &'a [W],
+    ) -> Result<Transaction<Transfer<'a, W>, W>, Error>;
+
+    /// Start a non-blocking full duplex transfer operation that reuses the same buffer for transmit
+    /// and receive. This will return a [`Transaction`] that can be processed by calling
+    /// [`NonBlocking::transfer_nonblocking`] until it completes.
+    fn start_nonblocking_duplex_transfer_inplace<'a>(
+        &mut self,
+        words: &'a mut [W],
+    ) -> Result<Transaction<TransferInplace<'a, W>, W>, Error>;
+
+    /// Process a transaction in a non-blocking manner. If the transaction completes during this
+    /// call, the method will return `Ok(None)`. If the transaction is still in progress, the method
+    /// will return `Ok(Some(transaction))`. If an error occurs during the transaction,
+    /// the method will return `Err(Error)`.
+    /// Upon completion of the transaction, or upon error the method will ensure that the SPI
+    /// peripheral is properly disabled and ready for the next operation.
+    #[allow(private_bounds)]
+    fn transfer_nonblocking<OP: Op<W>>(
+        &mut self,
+        transaction: Transaction<OP, W>,
+    ) -> Result<Option<Transaction<OP, W>>, Error>;
+}
+
+impl<SPI: Instance, W: Word> NonBlocking<W> for Spi<SPI, W> {
+    fn start_nonblocking_read<'a>(
+        &mut self,
+        buf: &'a mut [W],
+    ) -> Result<Transaction<Read<'a, W>, W>, Error> {
+        self.start_read(buf)
+    }
+
+    fn start_nonblocking_write<'a>(
+        &mut self,
+        words: &'a [W],
+    ) -> Result<Transaction<Write<'a, W>, W>, Error> {
+        self.start_write(words)
+    }
+
+    fn start_nonblocking_duplex_transfer<'a>(
+        &mut self,
+        read: &'a mut [W],
+        write: &'a [W],
+    ) -> Result<Transaction<Transfer<'a, W>, W>, Error> {
+        self.start_transfer(read, write)
+    }
+
+    fn start_nonblocking_duplex_transfer_inplace<'a>(
+        &mut self,
+        words: &'a mut [W],
+    ) -> Result<Transaction<TransferInplace<'a, W>, W>, Error> {
+        self.start_transfer_inplace(words)
+    }
+
+    #[allow(private_bounds)]
+    fn transfer_nonblocking<OP: Op<W>>(
+        &mut self,
+        transaction: Transaction<OP, W>,
+    ) -> Result<Option<Transaction<OP, W>>, Error> {
+        self.transfer_nonblocking_internal(transaction)
+    }
+}

--- a/src/spi/spi_def.rs
+++ b/src/spi/spi_def.rs
@@ -341,7 +341,7 @@ mod rm0481_common {
                 NoMosi,
                 #[cfg(feature = "h523_h533")]
                 gpio::PA8<Alternate<6>>,
-                #[cfg(feature = "stm32h523")]
+                #[cfg(feature = "h523_h533")]
                 gpio::PC1<Alternate<6>>,
                 gpio::PE6<Alternate<5>>,
                 gpio::PE14<Alternate<5>>

--- a/src/spi/spi_def.rs
+++ b/src/spi/spi_def.rs
@@ -1,0 +1,415 @@
+use core::marker::PhantomData;
+
+use super::{
+    Instance, NoMiso, NoMosi, NoSck, PinHCS, PinMiso, PinMosi, PinSck,
+    SupportedWordSize,
+};
+use crate::gpio::{self, Alternate};
+use crate::rcc::{rec, CoreClocks};
+use crate::stm32::{self, rcc::ccipr3, spi1, SPI1, SPI2, SPI3};
+use crate::time::Hertz;
+
+macro_rules! pins {
+    ($($SPIX:ty:
+       SCK: [$($( #[ $pmeta1:meta ] )* $SCK:ty),*]
+       MISO: [$($( #[ $pmeta2:meta ] )* $MISO:ty),*]
+       MOSI: [$($( #[ $pmeta3:meta ] )* $MOSI:ty),*]
+       HCS: [$($( #[ $pmeta4:meta ] )* $HCS:ty),*]
+    )+) => {
+        $(
+            $(
+                $( #[ $pmeta1 ] )*
+                impl PinSck<$SPIX> for $SCK {}
+            )*
+            $(
+                $( #[ $pmeta2 ] )*
+                impl PinMiso<$SPIX> for $MISO {}
+            )*
+            $(
+                $( #[ $pmeta3 ] )*
+                impl PinMosi<$SPIX> for $MOSI {}
+            )*
+            $(
+                $( #[ $pmeta4 ] )*
+                impl PinHCS<$SPIX> for $HCS {}
+            )*
+        )+
+    }
+}
+
+macro_rules! spi123_clock {
+    ($SPIX:ident) => { paste::item! {
+        fn clock(clocks: &CoreClocks) -> Hertz {
+            let ccipr3 = unsafe { (*stm32::RCC::ptr()).ccipr3().read() };
+            let ck_sel = ccipr3.[<$SPIX:lower sel>]().variant().expect("No source clock selected");
+            match ck_sel {
+                ccipr3::SPI123SEL::Pll1Q => clocks.pll1().q_ck(),
+                ccipr3::SPI123SEL::Pll2P => clocks.pll2().p_ck(),
+                ccipr3::SPI123SEL::Audioclk => clocks.audio_ck(),
+                ccipr3::SPI123SEL::PerCk => clocks.per_ck(),
+                #[cfg(feature = "rm0481")]
+                ccipr3::SPI123SEL::Pll3P => clocks.pll3().p_ck(),
+            }.expect("Source clock not enabled")
+        }
+    }}
+}
+
+#[allow(unused_macros)]
+macro_rules! spi456_clock {
+    ($SPIX:ident, $pclk:ident) => { paste::item! {
+        fn clock(clocks: &CoreClocks) -> Hertz {
+            let ccipr3 = unsafe { (*stm32::RCC::ptr()).ccipr3().read() };
+            let ck_sel = ccipr3.[<$SPIX:lower sel>]().variant().expect("No source clock selected");
+            match ck_sel {
+                ccipr3::SPI456SEL::Pclk => Some(clocks.$pclk()),
+                ccipr3::SPI456SEL::Pll2Q => clocks.pll2().q_ck(),
+                ccipr3::SPI456SEL::Pll3Q => clocks.pll3().q_ck(),
+                ccipr3::SPI456SEL::HsiKer => clocks.hsi_ck(),
+                ccipr3::SPI456SEL::CsiKer => clocks.csi_ck(),
+                ccipr3::SPI456SEL::Hse => clocks.hse_ck(),
+            }.expect("Source clock not enabled")
+        }
+    }}
+}
+
+// Implemented by all SPI instances
+macro_rules! instance {
+    ($SPIX:ident: $Spi:ident[$($word:ty),+], $SPICLKSEL:ident$(, $pclk:ident)?) => { paste::item! {
+        impl Instance for $SPIX {
+            type Rec = rec::$Spi;
+
+            fn ptr() -> *const spi1::RegisterBlock {
+                <$SPIX>::ptr() as *const _
+            }
+
+            [< $SPICLKSEL:lower _clock >]!($SPIX$(, $pclk)?);
+
+            fn rec() -> Self::Rec {
+                rec::$Spi { _marker: PhantomData }
+            }
+        }
+
+        impl crate::Sealed for $SPIX {}
+        $(impl SupportedWordSize<$word> for $SPIX {})+
+    }};
+
+}
+
+instance! { SPI1: Spi1[u8, u16, u32], SPI123 }
+instance! { SPI2: Spi2[u8, u16, u32], SPI123 }
+instance! { SPI3: Spi3[u8, u16, u32], SPI123 }
+
+#[cfg(feature = "rm0492")]
+mod rm492 {
+    use super::*;
+
+    pins! {
+        SPI1:
+            SCK: [
+                NoSck,
+                gpio::PA2<Alternate<4>>,
+                gpio::PA5<Alternate<5>>,
+                gpio::PA8<Alternate<12>>,
+                gpio::PB3<Alternate<5>>,
+                gpio::PC0<Alternate<5>>,
+                gpio::PC5<Alternate<5>>
+            ]
+            MISO: [
+                NoMiso,
+                gpio::PA0<Alternate<12>>,
+                gpio::PA3<Alternate<4>>,
+                gpio::PA6<Alternate<5>>,
+                gpio::PA9<Alternate<4>>,
+                gpio::PB4<Alternate<5>>,
+                gpio::PC2<Alternate<4>>,
+                gpio::PC10<Alternate<5>>
+            ]
+            MOSI: [
+                NoMosi,
+                gpio::PA4<Alternate<4>>,
+                gpio::PA7<Alternate<5>>,
+                gpio::PB5<Alternate<5>>,
+                gpio::PC3<Alternate<4>>,
+                gpio::PC7<Alternate<5>>
+            ]
+            HCS: [
+                gpio::PA1<Alternate<4>>,
+                gpio::PA4<Alternate<5>>,
+                gpio::PA15<Alternate<5>>,
+                gpio::PB8<Alternate<12>>,
+                gpio::PC1<Alternate<4>>,
+                gpio::PC8<Alternate<5>>
+            ]
+        SPI2:
+            SCK: [
+                NoSck,
+                gpio::PA5<Alternate<7>>,
+                gpio::PA9<Alternate<5>>,
+                gpio::PA12<Alternate<5>>,
+                gpio::PB2<Alternate<6>>,
+                gpio::PB10<Alternate<5>>,
+                gpio::PB13<Alternate<5>>
+            ]
+            MISO: [
+                NoMiso,
+                gpio::PA7<Alternate<11>>,
+                gpio::PA15<Alternate<7>>,
+                gpio::PB5<Alternate<6>>,
+                gpio::PB14<Alternate<5>>,
+                gpio::PC2<Alternate<5>>
+            ]
+            MOSI: [
+                NoMosi,
+                gpio::PA8<Alternate<6>>,
+                gpio::PB1<Alternate<6>>,
+                gpio::PB15<Alternate<5>>,
+                gpio::PC1<Alternate<5>>,
+                gpio::PC3<Alternate<5>>
+            ]
+            HCS: [
+                gpio::PA3<Alternate<5>>,
+                gpio::PA8<Alternate<11>>,
+                gpio::PA11<Alternate<5>>,
+                gpio::PB4<Alternate<7>>,
+                gpio::PB12<Alternate<5>>
+            ]
+        SPI3:
+            SCK: [
+                NoSck,
+                gpio::PA1<Alternate<6>>,
+                gpio::PA15<Alternate<10>>,
+                gpio::PB3<Alternate<6>>,
+                gpio::PB7<Alternate<6>>,
+                gpio::PC10<Alternate<6>>
+            ]
+            MISO: [
+                NoMiso,
+                gpio::PA2<Alternate<6>>,
+                gpio::PA4<Alternate<10>>,
+                gpio::PB4<Alternate<6>>,
+                gpio::PB15<Alternate<6>>,
+                gpio::PC11<Alternate<6>>
+            ]
+            MOSI: [
+                NoMosi,
+                gpio::PA3<Alternate<6>>,
+                gpio::PA5<Alternate<10>>,
+                gpio::PB2<Alternate<7>>,
+                gpio::PB5<Alternate<7>>,
+                gpio::PC12<Alternate<6>>,
+                gpio::PA9<Alternate<10>>
+            ]
+            HCS: [
+                gpio::PA4<Alternate<6>>,
+                gpio::PA15<Alternate<6>>,
+                gpio::PB10<Alternate<6>>,
+                gpio::PA0<Alternate<10>>,
+                gpio::PD2<Alternate<6>>
+            ]
+    }
+}
+
+// Note: pin data is taken from stm32h56x, stm32h573, stm32h523 and stm32h533 datasheets
+#[cfg(feature = "rm0481")]
+mod rm0481_common {
+    use super::*;
+    use crate::stm32::{SPI1, SPI2, SPI3, SPI4};
+
+    pins! {
+        SPI1:
+            SCK: [
+                NoSck,
+                gpio::PA5<Alternate<5>>,
+                gpio::PB3<Alternate<5>>,
+                gpio::PG11<Alternate<5>>
+            ]
+            MISO: [
+                NoMiso,
+                gpio::PA6<Alternate<5>>,
+                gpio::PB4<Alternate<5>>,
+                gpio::PG9<Alternate<5>>
+            ]
+            MOSI: [
+                NoMosi,
+                gpio::PA7<Alternate<5>>,
+                gpio::PB5<Alternate<5>>,
+                #[cfg(feature = "h523_h533")]
+                gpio::PB15<Alternate<6>>,
+                gpio::PD7<Alternate<5>>
+            ]
+            HCS: [
+                gpio::PA4<Alternate<5>>,
+                gpio::PA15<Alternate<5>>,
+                gpio::PG10<Alternate<5>>
+            ]
+        SPI2:
+            SCK: [
+                NoSck,
+                gpio::PA9<Alternate<5>>,
+                gpio::PA12<Alternate<5>>,
+                gpio::PB10<Alternate<5>>,
+                gpio::PB13<Alternate<5>>,
+                gpio::PD3<Alternate<5>>,
+                #[cfg(feature = "h56x_h573")]
+                gpio::PI1<Alternate<5>>
+            ]
+            MISO: [
+                NoMiso,
+                gpio::PB14<Alternate<5>>,
+                gpio::PC2<Alternate<5>>,
+                #[cfg(feature = "h56x_h573")]
+                gpio::PI2<Alternate<5>>
+            ]
+            MOSI: [
+                NoMosi,
+                gpio::PB15<Alternate<5>>,
+                gpio::PC1<Alternate<5>>,
+                gpio::PC3<Alternate<5>>,
+                gpio::PG1<Alternate<7>>,
+                #[cfg(feature = "h56x_h573")]
+                gpio::PI3<Alternate<5>>
+            ]
+            HCS: [
+                gpio::PA3<Alternate<5>>,
+                gpio::PA11<Alternate<5>>,
+                #[cfg(feature = "h523_h533")]
+                gpio::PB1<Alternate<5>>,
+                gpio::PB4<Alternate<7>>,
+                gpio::PB9<Alternate<5>>,
+                gpio::PB12<Alternate<5>>,
+                #[cfg(feature = "h56x_h573")]
+                gpio::PI0<Alternate<5>>
+            ]
+        SPI3:
+            SCK: [
+                NoSck,
+                #[cfg(feature = "h523_h533")]
+                gpio::PB1<Alternate<4>>,
+                gpio::PB3<Alternate<6>>,
+                #[cfg(feature = "h523_h533")]
+                gpio::PB9<Alternate<6>>,
+                gpio::PC10<Alternate<6>>
+            ]
+            MISO: [
+                NoMiso,
+                #[cfg(feature = "h523_h533")]
+                gpio::PB0<Alternate<5>>,
+                gpio::PB4<Alternate<6>>,
+                gpio::PC11<Alternate<6>>,
+                #[cfg(feature = "h523_h533")]
+                gpio::PD7<Alternate<6>>
+            ]
+            MOSI: [
+                NoMosi,
+                #[cfg(feature = "h523_h533")]
+                gpio::PA3<Alternate<6>>,
+                #[cfg(feature = "h523_h533")]
+                gpio::PA4<Alternate<4>>,
+                gpio::PB2<Alternate<7>>,
+                gpio::PB5<Alternate<7>>,
+                gpio::PC12<Alternate<6>>,
+                gpio::PD6<Alternate<5>>,
+                #[cfg(feature = "h523_h533")]
+                gpio::PG8<Alternate<5>>
+            ]
+            HCS: [
+                gpio::PA4<Alternate<6>>,
+                gpio::PA15<Alternate<6>>,
+                #[cfg(feature = "h523_h533")]
+                gpio::PB8<Alternate<6>>
+            ]
+        SPI4:
+            SCK: [
+                NoSck,
+                #[cfg(feature = "h523_h533")]
+                gpio::PA0<Alternate<5>>,
+                #[cfg(feature = "h523_h533")]
+                gpio::PC5<Alternate<6>>,
+                gpio::PE2<Alternate<5>>,
+                gpio::PE12<Alternate<5>>
+            ]
+            MISO: [
+                NoMiso,
+                #[cfg(feature = "h523_h533")]
+                gpio::PC0<Alternate<6>>,
+                #[cfg(feature = "h523_h533")]
+                gpio::PB7<Alternate<5>>,
+                gpio::PE5<Alternate<5>>,
+                gpio::PE13<Alternate<5>>
+            ]
+            MOSI: [
+                NoMosi,
+                #[cfg(feature = "h523_h533")]
+                gpio::PA8<Alternate<6>>,
+                #[cfg(feature = "stm32h523")]
+                gpio::PC1<Alternate<6>>,
+                gpio::PE6<Alternate<5>>,
+                gpio::PE14<Alternate<5>>
+            ]
+            HCS: [
+                gpio::PE4<Alternate<5>>,
+                gpio::PE11<Alternate<5>>
+            ]
+
+    }
+
+    instance! { SPI4: Spi4[u8, u16], SPI456, pclk2 }
+}
+
+#[cfg(feature = "h56x_h573")]
+mod h56x_h573 {
+    use super::*;
+    use crate::stm32::{SPI5, SPI6};
+    pins! {
+        SPI5:
+            SCK: [
+                NoSck,
+                gpio::PF7<Alternate<5>>,
+                gpio::PH6<Alternate<5>>
+            ]
+            MISO: [
+                NoMiso,
+                gpio::PF8<Alternate<5>>,
+                gpio::PH7<Alternate<5>>
+            ]
+            MOSI: [
+                NoMosi,
+                gpio::PF9<Alternate<5>>,
+                gpio::PF11<Alternate<5>>,
+                gpio::PH8<Alternate<5>>
+            ]
+            HCS: [
+                gpio::PF6<Alternate<5>>,
+                gpio::PH5<Alternate<5>>,
+                gpio::PH9<Alternate<5>>
+            ]
+        SPI6:
+            SCK: [
+                NoSck,
+                gpio::PA5<Alternate<8>>,
+                gpio::PB3<Alternate<8>>,
+                gpio::PC12<Alternate<5>>,
+                gpio::PG13<Alternate<5>>
+            ]
+            MISO: [
+                NoMiso,
+                gpio::PA6<Alternate<8>>,
+                gpio::PB4<Alternate<8>>,
+                gpio::PG12<Alternate<5>>
+            ]
+            MOSI: [
+                NoMosi,
+                gpio::PA7<Alternate<8>>,
+                gpio::PB5<Alternate<8>>,
+                gpio::PG14<Alternate<5>>
+            ]
+            HCS: [
+                gpio::PA0<Alternate<5>>,
+                gpio::PA4<Alternate<8>>,
+                gpio::PA15<Alternate<7>>,
+                gpio::PG8<Alternate<5>>
+            ]
+    }
+    instance! { SPI5: Spi5[u8, u16], SPI456, pclk3 }
+    instance! { SPI6: Spi6[u8, u16], SPI456, pclk2 }
+}

--- a/src/spi/transaction.rs
+++ b/src/spi/transaction.rs
@@ -233,7 +233,10 @@ impl<'a, OP, W> Transaction<OP, W> {
 impl<OP: Op<W>, W> Transaction<OP, W> {
     #[inline(always)]
     pub(super) fn is_complete(&mut self) -> bool {
-        self.is_read_complete() && self.is_write_complete()
+        self.is_read_complete()
+            && self.rx_remainder_to_discard() == 0
+            && self.is_write_complete()
+            && self.tx_flush_remainder() == 0
     }
 
     #[inline(always)]

--- a/src/spi/transaction.rs
+++ b/src/spi/transaction.rs
@@ -1,0 +1,280 @@
+//! This module abstracts the handling of SPI transactions with different buffer access patterns.
+//! The Transaction struct encapsulates the buffer access operations for reading and writing data
+//! that can be passed repeatedly to the driver for performing non-blocking operations.
+use core::marker::PhantomData;
+
+/// Trait for SPI transaction operations. This defines the buffer accesses for each type of SPI
+/// operation (read, write, transfer, etc.).
+pub(super) trait Op<W = u8> {
+    fn read_buf(&mut self) -> &mut [W];
+    fn read_idx(&mut self) -> &mut usize;
+    fn read_len(&self) -> usize;
+    fn write_buf(&self) -> &[W];
+    fn write_idx(&mut self) -> &mut usize;
+    fn write_len(&self) -> usize;
+}
+
+/// Read operation for a SPI transaction
+pub struct Read<'a, W = u8> {
+    read_idx: usize,
+    write_idx: usize, // Number of bytes flushed out the TX buffer to generate clocks for read operations on full duplex bus
+    buf: &'a mut [W],
+}
+
+impl<W> Op<W> for Read<'_, W> {
+    #[inline(always)]
+    fn read_buf(&mut self) -> &mut [W] {
+        self.buf
+    }
+
+    #[inline(always)]
+    fn read_idx(&mut self) -> &mut usize {
+        &mut self.read_idx
+    }
+
+    #[inline(always)]
+    fn read_len(&self) -> usize {
+        self.buf.len()
+    }
+
+    #[inline(always)]
+    fn write_buf(&self) -> &[W] {
+        panic!("Read operation!") // The write buffer is not used in a read operation
+    }
+
+    #[inline(always)]
+    fn write_idx(&mut self) -> &mut usize {
+        &mut self.write_idx
+    }
+
+    #[inline(always)]
+    fn write_len(&self) -> usize {
+        0
+    }
+}
+
+/// Write operation for a SPI transaction
+pub struct Write<'a, W = u8> {
+    read_idx: usize, // Number of bytes discarded from RX buffer for write operations on full duplex bus
+    write_idx: usize,
+    out: &'a [W],
+}
+
+impl<W> Op<W> for Write<'_, W> {
+    #[inline(always)]
+    fn read_buf(&mut self) -> &mut [W] {
+        panic!("Write operation!") // The read buffer is not used in a write operation
+    }
+
+    #[inline(always)]
+    fn read_idx(&mut self) -> &mut usize {
+        &mut self.read_idx
+    }
+
+    #[inline(always)]
+    fn read_len(&self) -> usize {
+        0
+    }
+
+    #[inline(always)]
+    fn write_buf(&self) -> &[W] {
+        self.out
+    }
+
+    #[inline(always)]
+    fn write_idx(&mut self) -> &mut usize {
+        &mut self.write_idx
+    }
+
+    #[inline(always)]
+    fn write_len(&self) -> usize {
+        self.out.len()
+    }
+}
+
+pub struct Transfer<'a, W = u8> {
+    read_idx: usize,
+    write_idx: usize,
+    read: &'a mut [W],
+    write: &'a [W],
+}
+
+/// Bidirectional transfer operation for a SPI transaction
+impl<W> Op<W> for Transfer<'_, W> {
+    #[inline(always)]
+    fn read_buf(&mut self) -> &mut [W] {
+        self.read
+    }
+
+    #[inline(always)]
+    fn read_idx(&mut self) -> &mut usize {
+        &mut self.read_idx
+    }
+
+    #[inline(always)]
+    fn read_len(&self) -> usize {
+        self.read.len()
+    }
+
+    #[inline(always)]
+    fn write_buf(&self) -> &[W] {
+        self.write
+    }
+
+    #[inline(always)]
+    fn write_idx(&mut self) -> &mut usize {
+        &mut self.write_idx
+    }
+
+    #[inline(always)]
+    fn write_len(&self) -> usize {
+        self.write.len()
+    }
+}
+
+/// Bidirectional transfer operation for a SPI transaction that modifies the same buffer in place
+pub struct TransferInplace<'a, W = u8> {
+    read_idx: usize,
+    write_idx: usize,
+    buf: &'a mut [W],
+}
+
+impl<W> Op<W> for TransferInplace<'_, W> {
+    #[inline(always)]
+    fn read_buf(&mut self) -> &mut [W] {
+        self.buf
+    }
+
+    #[inline(always)]
+    fn read_idx(&mut self) -> &mut usize {
+        &mut self.read_idx
+    }
+
+    #[inline(always)]
+    fn read_len(&self) -> usize {
+        self.buf.len()
+    }
+
+    #[inline(always)]
+    fn write_buf(&self) -> &[W] {
+        self.buf
+    }
+
+    #[inline(always)]
+    fn write_idx(&mut self) -> &mut usize {
+        &mut self.write_idx
+    }
+
+    #[inline(always)]
+    fn write_len(&self) -> usize {
+        self.buf.len()
+    }
+}
+
+#[derive(Debug)]
+pub struct Transaction<OP, W> {
+    op: OP,
+    _word_type: PhantomData<W>,
+}
+
+impl<'a, OP, W> Transaction<OP, W> {
+    pub(super) fn read(buf: &'a mut [W]) -> Transaction<Read<'a, W>, W> {
+        Transaction::<Read<'a, W>, W> {
+            op: Read {
+                read_idx: 0,
+                write_idx: 0,
+                buf,
+            },
+            _word_type: PhantomData,
+        }
+    }
+
+    pub(super) fn write(out: &'a [W]) -> Transaction<Write<'a, W>, W> {
+        Transaction::<Write<'a, W>, W> {
+            op: Write {
+                read_idx: 0,
+                write_idx: 0,
+                out,
+            },
+            _word_type: PhantomData,
+        }
+    }
+
+    pub(super) fn transfer(
+        write: &'a [W],
+        read: &'a mut [W],
+    ) -> Transaction<Transfer<'a, W>, W> {
+        Transaction::<Transfer<'a, W>, W> {
+            op: Transfer {
+                read_idx: 0,
+                write_idx: 0,
+                read,
+                write,
+            },
+            _word_type: PhantomData,
+        }
+    }
+
+    pub(super) fn transfer_inplace(
+        buf: &'a mut [W],
+    ) -> Transaction<TransferInplace<'a, W>, W> {
+        Transaction::<TransferInplace<'a, W>, W> {
+            op: TransferInplace {
+                read_idx: 0,
+                write_idx: 0,
+                buf,
+            },
+            _word_type: PhantomData,
+        }
+    }
+}
+
+#[allow(private_bounds)]
+impl<OP: Op<W>, W> Transaction<OP, W> {
+    #[inline(always)]
+    pub(super) fn is_complete(&mut self) -> bool {
+        self.is_read_complete() && self.is_write_complete()
+    }
+
+    #[inline(always)]
+    pub(super) fn is_read_complete(&mut self) -> bool {
+        *self.op.read_idx() >= self.op.read_len()
+    }
+
+    #[inline(always)]
+    pub(super) fn is_write_complete(&mut self) -> bool {
+        *self.op.write_idx() >= self.op.write_len()
+    }
+
+    #[inline(always)]
+    pub(super) fn read_buf(&mut self) -> &mut [W] {
+        let read_idx = *self.op.read_idx();
+        &mut self.op.read_buf()[read_idx..]
+    }
+
+    #[inline(always)]
+    pub(super) fn write_buf(&mut self) -> &[W] {
+        let write_idx = *self.op.write_idx();
+        &self.op.write_buf()[write_idx..]
+    }
+
+    #[inline(always)]
+    pub(super) fn advance_write_idx(&mut self, count: usize) {
+        *self.op.write_idx() += count;
+    }
+
+    #[inline(always)]
+    pub(super) fn advance_read_idx(&mut self, count: usize) {
+        *self.op.read_idx() += count;
+    }
+
+    #[inline(always)]
+    pub(super) fn rx_remainder_to_discard(&mut self) -> usize {
+        self.op.write_len().saturating_sub(*self.op.read_idx())
+    }
+
+    #[inline(always)]
+    pub(super) fn tx_flush_remainder(&mut self) -> usize {
+        self.op.read_len().saturating_sub(*self.op.write_idx())
+    }
+}


### PR DESCRIPTION
This adds a master mode implementation for the SPI peripheral. 

The driver is split such that the core logic is implemented in spi.rs, and the rest is contained within a submodule:
- User configuration is split off into the config module
- The transaction module encapsulates the different transaction types (read, write, transfer, transfer inplace). Buffer management is abstracted into the transaction type to enable non-blocking usage the peripheral.
- The public facing APIs are mostly implemented in the hal module (embedded-hal trait implementations), and the nonblocking module, which exposes a NonBlocking trait that a user needs to explicitly use in order to use the non-blocking APIs (expected to be the less used case, this avoids polluting the public API too much).