### PR TITLE
Add cross configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,8 @@
 {
     "rust-analyzer.cargo.features": [
         "rt",
-        "stm32h503"
+        "stm32h503",
+        "async",
     ],
     "rust-analyzer.check.allTargets": false,
     "rust-analyzer.check.targets": "thumbv8m.main-none-eabihf",

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,9 +1,6 @@
 # Cross doesn't seem to look for package specific configurations when invoked in a workspace so
 # we put the default target in Cross.toml
 
-[build]
-default-target = "aarch64-unknown-linux-gnu"
-
 # Allow usage of locally built version of the cross docker image that matches the host architecture
 # e.g. Building a linux/arm64 image for an AARCH64 host allows native execution of the image.
 # Specifying the toolchain for a linux/arm64 image means the correct toolchain is used on that

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,13 @@
+# Cross doesn't seem to look for package specific configurations when invoked in a workspace so
+# we put the default target in Cross.toml
+
+[build]
+default-target = "aarch64-unknown-linux-gnu"
+
+# Allow usage of locally built version of the cross docker image that matches the host architecture
+# e.g. Building a linux/arm64 image for an AARCH64 host allows native execution of the image.
+# Specifying the toolchain for a linux/arm64 image means the correct toolchain is used on that
+# platform (it defaults to x86_64).
+[target.aarch64-unknown-linux-gnu.image]
+name = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main"
+toolchain = ["linux/arm64=aarch64-unknown-linux-gnu"]

--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ a number of fantastic resources available to help.
 - [Rust Embedded FAQ](https://docs.rust-embedded.org/faq.html)
 - [rust-embedded/awesome-embedded-rust](https://github.com/rust-embedded/awesome-embedded-rust)
 
+## Running unit tests
+
+First, you'll need to install the `aarch64-unknown-linux-gnu` target to run unit tests.
+
+If you're on a linux host, you can to run unit tests with `cargo test`.
+
+If you're not, you'll need to install [`cross`](https://github.com/cross-rs/cross), which is a cross compilation tool. See the `cross` instructions for details of installation and use. Once that is installed, using `cross test` will run the unit tests within a docker image.
+
+Running tests with `cross`:
+
+    cross test --target x86_64-unknown-linux-gnu --tests --features stm32h503
+
+`cross` will automatically download the relevant docker image and install the correct rust toolchain.
+
 ## Changelog
 
 See [CHANGELOG.md](CHANGELOG.md). Note: this will be populated once the first crates have been

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ a number of fantastic resources available to help.
 
 ## Running unit tests
 
-First, you'll need to install the `aarch64-unknown-linux-gnu` target to run unit tests.
+If you're on a linux host, you can simply run unit tests with:
 
-If you're on a linux host, you can to run unit tests with `cargo test`.
+    cargo test --target x86_64-unknown-linux-gnu --tests --features stm32h503
 
 If you're not, you'll need to install [`cross`](https://github.com/cross-rs/cross), which is a cross compilation tool. See the `cross` instructions for details of installation and use. Once that is installed, using `cross test` will run the unit tests within a docker image.
 


### PR DESCRIPTION
This allows running unit tests on a non-linux platform via the `cross test` command.