### PR TITLE
serial: Add asynchronous serial driver for U(S)ARTs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ stm32h5 = { package = "stm32h5", version = "0.16.0" }
 fugit = "0.3.7"
 embedded-dma = "0.2"
 embedded-hal = "1.0.0"
+embedded-io = "0.6.1"
 defmt = { version = "1.0.0", optional = true }
 paste = "1.0.15"
 log = { version = "0.4.20", optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ stm32h5 = { package = "stm32h5", version = "0.16.0" }
 fugit = "0.3.7"
 embedded-dma = "0.2"
 embedded-hal = "1.0.0"
-embedded-io = "0.6.1"
+embedded-io = "0.7.1"
 defmt = { version = "1.0.0", optional = true }
 paste = "1.0.15"
 log = { version = "0.4.20", optional = true}

--- a/examples/usart.rs
+++ b/examples/usart.rs
@@ -1,0 +1,62 @@
+// #![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use cortex_m_rt::entry;
+mod utilities;
+use embedded_hal::delay::DelayNs;
+use embedded_io::{Read, Write};
+use stm32h5xx_hal::{delay::Delay, pac, prelude::*, time::MilliSeconds};
+
+use log::info;
+
+
+#[entry]
+fn main() -> ! {
+    utilities::logger::init();
+    let cp = cortex_m::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Constrain and Freeze power
+    info!("Setup PWR...                  ");
+    let pwr = dp.PWR.constrain();
+    let pwrcfg = pwr.freeze();
+
+    // Constrain and Freeze clock
+    info!("Setup RCC...                  ");
+    let rcc = dp.RCC.constrain();
+    let ccdr = rcc
+        .sys_ck(192.MHz())
+        .pll1_q_ck(64.MHz())
+        .freeze(pwrcfg, &dp.SBS);
+
+    // Acquire the GPIOA peripheral. This also enables the clock for
+    // GPIOA in the RCC register.
+    let gpioa = dp.GPIOA.split(ccdr.peripheral.GPIOA);
+
+    let rx = gpioa.pa11.into_alternate();
+    let tx = gpioa.pa12.into_alternate();
+
+    info!("");
+    info!("stm32h5xx-hal example - USART");
+    info!("");
+
+    // Initialise the USART peripheral.
+    let mut serial = dp
+        .USART2
+        .serial((tx, rx), 115200.Hz(), ccdr.peripheral.USART2, &ccdr.clocks)
+        .unwrap();
+
+    let mut delay = Delay::new(cp.SYST, &ccdr.clocks);
+    let duration = MilliSeconds::secs(1).to_millis();
+    // Echo what is received on the USART
+    let mut write = 'A';
+    let read = &mut [0u8; 1];
+    loop {
+        serial.write(&[write as u8]).unwrap();
+        serial.read(read).unwrap();
+        info!("Received: {}", read[0] as char);
+        write = (write as u8).wrapping_add(1) as char;
+        delay.delay_ms(duration);
+    }
+}

--- a/examples/usart.rs
+++ b/examples/usart.rs
@@ -1,4 +1,4 @@
-// #![deny(warnings)]
+#![deny(warnings)]
 #![no_main]
 #![no_std]
 

--- a/examples/usart.rs
+++ b/examples/usart.rs
@@ -10,7 +10,6 @@ use stm32h5xx_hal::{delay::Delay, pac, prelude::*, time::MilliSeconds};
 
 use log::info;
 
-
 #[entry]
 fn main() -> ! {
     utilities::logger::init();
@@ -30,12 +29,14 @@ fn main() -> ! {
         .pll1_q_ck(64.MHz())
         .freeze(pwrcfg, &dp.SBS);
 
-    // Acquire the GPIOA peripheral. This also enables the clock for
-    // GPIOA in the RCC register.
-    let gpioa = dp.GPIOA.split(ccdr.peripheral.GPIOA);
+    // Acquire the GPIOB peripheral. This also enables the clock for
+    // GPIOB in the RCC register.
+    let gpiob = dp.GPIOB.split(ccdr.peripheral.GPIOB);
 
-    let rx = gpioa.pa11.into_alternate();
-    let tx = gpioa.pa12.into_alternate();
+    // Connect TX and RX pins together for this to work. On the Nucleo-H503 this is pins 35 & 37 on
+    // CN10
+    let rx = gpiob.pb15.into_alternate();
+    let tx = gpiob.pb14.into_alternate();
 
     info!("");
     info!("stm32h5xx-hal example - USART");
@@ -43,20 +44,23 @@ fn main() -> ! {
 
     // Initialise the USART peripheral.
     let mut serial = dp
-        .USART2
-        .serial((tx, rx), 115200.Hz(), ccdr.peripheral.USART2, &ccdr.clocks)
+        .USART1
+        .serial((tx, rx), 115200.Hz(), ccdr.peripheral.USART1, &ccdr.clocks)
         .unwrap();
 
     let mut delay = Delay::new(cp.SYST, &ccdr.clocks);
     let duration = MilliSeconds::secs(1).to_millis();
     // Echo what is received on the USART
-    let mut write = 'A';
-    let read = &mut [0u8; 1];
+    let read = &mut [0u8; 6];
+    let mut count = 1;
     loop {
-        serial.write(&[write as u8]).unwrap();
-        serial.read(read).unwrap();
-        info!("Received: {}", read[0] as char);
-        write = (write as u8).wrapping_add(1) as char;
+        // Note: the USART driver uses a FIFO, so as long as we keep the messages below the FIFO
+        // size we won't miss any data.
+        write!(serial, "Test {count}").unwrap();
+        count = (count + 1) % 10;
+        serial.read_exact(read).unwrap();
+        let received = core::str::from_utf8(read).unwrap();
+        info!("Received: {}", received);
         delay.delay_ms(duration);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,9 @@ pub mod usb;
 pub mod gpdma;
 
 #[cfg(feature = "device-selected")]
+pub mod serial;
+
+#[cfg(feature = "device-selected")]
 mod sealed {
     pub trait Sealed {}
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -8,8 +8,8 @@ pub use crate::i2c::I2cExt as _stm32h5xx_hal_i2c_I2cExt;
 pub use crate::icache::ICacheExt as _stm32h5xx_hal_icache_ICacheExt;
 pub use crate::pwr::PwrExt as _stm32h5xx_hal_pwr_PwrExt;
 pub use crate::rcc::RccExt as _stm32h5xx_hal_rcc_RccExt;
-pub use crate::spi::SpiExt as _stm32h5xx_hal_spi_SpiExt;
 pub use crate::serial::usart::SerialExt as _stm32h5xx_hal_serial_SerialExt;
+pub use crate::spi::SpiExt as _stm32h5xx_hal_spi_SpiExt;
 pub use crate::usb::UsbExt as _stm32h5xx_hal_usb_UsbExt;
 
 pub use crate::time::U32Ext as _;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,6 +9,7 @@ pub use crate::icache::ICacheExt as _stm32h5xx_hal_icache_ICacheExt;
 pub use crate::pwr::PwrExt as _stm32h5xx_hal_pwr_PwrExt;
 pub use crate::rcc::RccExt as _stm32h5xx_hal_rcc_RccExt;
 pub use crate::spi::SpiExt as _stm32h5xx_hal_spi_SpiExt;
+pub use crate::serial::usart::SerialExt as _stm32h5xx_hal_serial_SerialExt;
 pub use crate::usb::UsbExt as _stm32h5xx_hal_usb_UsbExt;
 
 pub use crate::time::U32Ext as _;

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -64,6 +64,8 @@
 //! [io::WriteReady]: https://docs.rs/embedded-io/0.6.1/embedded_io/trait.WriteReady.html
 //! [embedded-io]: https://docs.rs/embedded-io/0.6.1/embedded_io/
 
+use core::fmt::Display;
+
 use embedded_io::{Error as IoError, ErrorKind as IoErrorKind};
 
 pub mod config;
@@ -86,6 +88,13 @@ pub enum Error {
     Parity,
 }
 
+impl Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl core::error::Error for Error {}
 
 impl IoError for Error {
     fn kind(&self) -> IoErrorKind {

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1,0 +1,127 @@
+//! Serial communication using USART & LPUART peripherals
+//!
+//! The serial module provides both asynchronous and synchronous functionality using the USART
+//! and LPUART* (only asynchronous) peripherals. It also exposes some, but not all, of the advanced
+//! functionality provided by the USART peripheral.
+//!
+//! It supports both blocking and non-blocking usage. Non-blocking usage is provided via the
+//! embedded-hal-nb crate's [`Read`][serial::Read] and [`Write`][serial::Write] traits, while
+//! blocking usage is abstracted as an IO stream and is exposed via embedded-io traits:
+//! [`Read`][io::Read], [`ReadReady`][io::ReadReady], [`Write`][io::Write], and
+//! [`WriteReady`][io::WriteReady] are implemented.
+//!
+//! 7, 8, and 9-bit word sizes are supported. For 7- and 8-bit operation, transactions are performed
+//! with u8 values. For 9-bit operation transactions are performed with u16 values. The correct word
+//! size must be indicated to the compiler during initialization.
+//!
+//! # Usage
+//!
+//! ## Asynchronous serial via USART
+//!
+//! ### Intialization:
+//! ```
+//! use smt32h5xx_hal::serial;
+//!
+//! let dp = ...;           // Device peripherals
+//! let (tx, rx) = ...;     // Configure pin
+//!
+//! let serial = dp.USART1
+//!         .serial((tx, rx), 115_200.Hz(), ccdr.peripheral.USART1, &ccdr.clocks)
+//!         .unwrap();
+//! ```
+//!
+//! ### Non-blocking operation
+//! ```
+//! use smt32h5xx_hal::serial;
+//! use embedded_hal_nb::serial;
+//!
+//! nb::block!(serial.write(0x00)).unwrap();
+//! let b = nb::block!(serial.read()).unwrap();
+//! ```
+//!
+//! ### Blocking operation
+//!
+//! ```
+//! use smt32h5xx_hal::serial;
+//! use embedded_hal_nb::serial;
+//!
+//! let bytes_written = serial.write(&[0x00, 0x11, 0x22]).unwrap();
+//! let buf = &mut [0u8; 3];
+//! let bytes_read = serial.read(buf).unwrap();
+//! ```
+//!
+//! * Note: LPUART funcitionality is not yet implemented
+//!
+//! # Examples
+//!
+//! - [Simple Blocking Example](https://github.com/stm32-rs/stm32h7xx-hal/blob/master/examples/serial.rs)
+//!
+//! [serial::Read]: https://docs.rs/embedded-hal-nb/1.0.0-rc.1/embedded_hal_nb/serial/trait.Read.html
+//! [serial::Write]: https://docs.rs/embedded-hal-nb/1.0.0-rc.1/embedded_hal_nb/serial/trait.Write.html
+//! [io::Read]: https://docs.rs/embedded-io/0.6.1/embedded_io/trait.Read.html
+//! [io::ReadReady]: https://docs.rs/embedded-io/0.6.1/embedded_io/trait.ReadReady.html
+//! [io::Write]: https://docs.rs/embedded-io/0.6.1/embedded_io/trait.Write.html
+//! [io::WriteReady]: https://docs.rs/embedded-io/0.6.1/embedded_io/trait.WriteReady.html
+//! [embedded-io]: https://docs.rs/embedded-io/0.6.1/embedded_io/
+
+use embedded_io::{Error as IoError, ErrorKind as IoErrorKind};
+
+pub mod config;
+pub(crate) mod usart;
+
+pub use usart::{Instance, Serial, PinCk, PinRx, PinTx, NoCk, NoRx, NoTx};
+
+/// Serial error
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum Error {
+    /// Framing error
+    Framing,
+    /// Noise error
+    Noise,
+    /// RX buffer overrun
+    Overrun,
+    /// Parity check error
+    Parity,
+}
+
+
+impl IoError for Error {
+    fn kind(&self) -> IoErrorKind {
+        match self {
+            Error::Overrun => IoErrorKind::Other,
+            Error::Framing => IoErrorKind::Other,
+            Error::Noise => IoErrorKind::Other,
+            Error::Parity => IoErrorKind::Other,
+        }
+    }
+}
+
+/// Interrupt event
+#[derive(Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Event {
+    /// Rx FIFO not empty
+    RxNotEmpty,
+    /// Tx FIFO not full
+    TxNotFull,
+    /// Idle line state detected
+    Idle,
+    ///Tx FIFO below threshlold
+    TxFifoThreshold,
+    ///Rx FIFO above threshold
+    RxFifoThreshold,
+}
+
+pub trait WordBits: Copy + Default {
+    const BITS: usize;
+}
+
+impl WordBits for u16 {
+    const BITS: usize = u16::BITS as usize;
+}
+
+impl WordBits for u8 {
+    const BITS: usize = u8::BITS as usize;
+}

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -71,7 +71,7 @@ use embedded_io::{Error as IoError, ErrorKind as IoErrorKind};
 pub mod config;
 pub(crate) mod usart;
 
-pub use usart::{Instance, Serial, PinCk, PinRx, PinTx, NoCk, NoRx, NoTx};
+pub use usart::{Instance, NoCk, NoRx, NoTx, PinCk, PinRx, PinTx, Serial};
 
 /// Serial error
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1,13 +1,11 @@
 //! Serial communication using USART & LPUART peripherals
 //!
 //! The serial module provides both asynchronous and synchronous functionality using the USART
-//! and LPUART* (only asynchronous) peripherals. It also exposes some, but not all, of the advanced
+//! and LPUART (only asynchronous) peripherals*. It also exposes some, but not all, of the advanced
 //! functionality provided by the USART peripheral.
 //!
-//! It supports both blocking and non-blocking usage. Non-blocking usage is provided via the
-//! embedded-hal-nb crate's [`Read`][serial::Read] and [`Write`][serial::Write] traits, while
-//! blocking usage is abstracted as an IO stream and is exposed via embedded-io traits:
-//! [`Read`][io::Read], [`ReadReady`][io::ReadReady], [`Write`][io::Write], and
+//! The serial interface is abstracted as an IO stream and access is exposed via embedded-io
+//! traits: [`Read`][io::Read], [`ReadReady`][io::ReadReady], [`Write`][io::Write], and
 //! [`WriteReady`][io::WriteReady] are implemented.
 //!
 //! 7, 8, and 9-bit word sizes are supported. For 7- and 8-bit operation, transactions are performed
@@ -20,8 +18,6 @@
 //!
 //! ### Intialization:
 //! ```
-//! use smt32h5xx_hal::serial;
-//!
 //! let dp = ...;           // Device peripherals
 //! let (tx, rx) = ...;     // Configure pin
 //!
@@ -30,39 +26,28 @@
 //!         .unwrap();
 //! ```
 //!
-//! ### Non-blocking operation
-//! ```
-//! use smt32h5xx_hal::serial;
-//! use embedded_hal_nb::serial;
-//!
-//! nb::block!(serial.write(0x00)).unwrap();
-//! let b = nb::block!(serial.read()).unwrap();
-//! ```
-//!
-//! ### Blocking operation
+//! ### Operation:
+//! Use the [embedded-io] traits to read and write data from/to the serial interface.
 //!
 //! ```
-//! use smt32h5xx_hal::serial;
-//! use embedded_hal_nb::serial;
+//! use embedded_io::{Read, Write};
 //!
 //! let bytes_written = serial.write(&[0x00, 0x11, 0x22]).unwrap();
 //! let buf = &mut [0u8; 3];
 //! let bytes_read = serial.read(buf).unwrap();
 //! ```
 //!
-//! * Note: LPUART funcitionality is not yet implemented
+//! * Note: Synchronous and LPUART functionality is not yet implemented
 //!
 //! # Examples
 //!
 //! - [Simple Blocking Example](https://github.com/stm32-rs/stm32h7xx-hal/blob/master/examples/serial.rs)
 //!
-//! [serial::Read]: https://docs.rs/embedded-hal-nb/1.0.0-rc.1/embedded_hal_nb/serial/trait.Read.html
-//! [serial::Write]: https://docs.rs/embedded-hal-nb/1.0.0-rc.1/embedded_hal_nb/serial/trait.Write.html
-//! [io::Read]: https://docs.rs/embedded-io/0.6.1/embedded_io/trait.Read.html
-//! [io::ReadReady]: https://docs.rs/embedded-io/0.6.1/embedded_io/trait.ReadReady.html
-//! [io::Write]: https://docs.rs/embedded-io/0.6.1/embedded_io/trait.Write.html
-//! [io::WriteReady]: https://docs.rs/embedded-io/0.6.1/embedded_io/trait.WriteReady.html
-//! [embedded-io]: https://docs.rs/embedded-io/0.6.1/embedded_io/
+//! [io::Read]: https://docs.rs/embedded-io/latest/embedded_io/trait.Read.html
+//! [io::ReadReady]: https://docs.rs/embedded-io/latest/embedded_io/trait.ReadReady.html
+//! [io::Write]: https://docs.rs/embedded-io/latest/embedded_io/trait.Write.html
+//! [io::WriteReady]: https://docs.rs/embedded-io/latest/embedded_io/trait.WriteReady.html
+//! [embedded-io]: https://docs.rs/embedded-io/latest/embedded_io/
 
 use core::fmt::Display;
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -83,12 +83,7 @@ impl core::error::Error for Error {}
 
 impl IoError for Error {
     fn kind(&self) -> IoErrorKind {
-        match self {
-            Error::Overrun => IoErrorKind::Other,
-            Error::Framing => IoErrorKind::Other,
-            Error::Noise => IoErrorKind::Other,
-            Error::Parity => IoErrorKind::Other,
-        }
+        IoErrorKind::Other
     }
 }
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -41,7 +41,7 @@
 //!
 //! # Examples
 //!
-//! - [Simple Blocking Example](https://github.com/stm32-rs/stm32h7xx-hal/blob/master/examples/serial.rs)
+//! - [Simple (Blocking) Example](https://github.com/stm32-rs/stm32h5xx-hal/blob/master/examples/usart.rs)
 //!
 //! [io::Read]: https://docs.rs/embedded-io/latest/embedded_io/trait.Read.html
 //! [io::ReadReady]: https://docs.rs/embedded-io/latest/embedded_io/trait.ReadReady.html

--- a/src/serial/config.rs
+++ b/src/serial/config.rs
@@ -1,0 +1,220 @@
+use crate::time::Hertz;
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum FifoThreshold {
+    /// Only valid for Tx Threshold
+    Empty,
+    Eighth,
+    Quarter,
+    Half,
+    ThreeQuarter,
+    SevenEighth,
+    /// Only valid for Rx Threshold
+    Full,
+}
+
+/// The parity bits appended to each serial data word
+///
+/// When enabled parity bits will be automatically added by hardware on transmit, and automatically checked by
+/// hardware on receive. For example, `read()` would return [`Error::Parity`](super::Error::Parity).
+///
+/// Note that parity bits are included in the serial word length, so if parity is used word length will be set to 9.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum Parity {
+    ParityNone,
+    ParityEven,
+    ParityOdd,
+}
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum StopBits {
+    #[doc = "1 stop bit"]
+    Stop1,
+    #[doc = "0.5 stop bits"]
+    Stop0p5,
+    #[doc = "2 stop bits"]
+    Stop2,
+    #[doc = "1.5 stop bits"]
+    Stop1p5,
+}
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum BitOrder {
+    LsbFirst,
+    MsbFirst,
+}
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum ClockPhase {
+    First,
+    Second,
+}
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum ClockPolarity {
+    IdleHigh,
+    IdleLow,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum WordSize {
+    DataBits7,
+    DataBits8,
+    DataBits9,
+}
+
+/// A structure for specifying the USART configuration
+///
+/// This structure uses the builder pattern to generate the configuration:
+///
+/// ```
+/// let config = Config::new().partity_odd();
+/// ```
+#[derive(Copy, Clone)]
+pub struct Config {
+    pub baudrate: Hertz,
+    pub parity: Parity,
+    pub stop_bits: StopBits,
+    pub bit_order: BitOrder,
+    pub clock_phase: ClockPhase,
+    pub clock_polarity: ClockPolarity,
+    pub last_bit_clock_pulse: bool,
+    pub swap_txrx: bool,
+    pub invert_rx: bool,
+    pub invert_tx: bool,
+    pub rx_fifo_threshold: FifoThreshold,
+    pub tx_fifo_threshold: FifoThreshold,
+    pub half_duplex: bool,
+    pub word_size: WordSize,
+}
+
+impl Config {
+    /// Create a default configuration for the USART or UART interface
+    ///
+    /// * 8 bits, 1 stop bit, no parity (8N1)
+    /// * LSB first
+    pub fn new(frequency: Hertz) -> Self {
+        Config {
+            baudrate: frequency,
+            parity: Parity::ParityNone,
+            stop_bits: StopBits::Stop1,
+            bit_order: BitOrder::LsbFirst,
+            clock_phase: ClockPhase::First,
+            clock_polarity: ClockPolarity::IdleLow,
+            last_bit_clock_pulse: false,
+            swap_txrx: false,
+            invert_rx: false,
+            invert_tx: false,
+            rx_fifo_threshold: FifoThreshold::Eighth,
+            tx_fifo_threshold: FifoThreshold::Eighth,
+            half_duplex: false,
+            word_size: WordSize::DataBits8,
+        }
+    }
+
+    pub fn baudrate(mut self, baudrate: Hertz) -> Self {
+        self.baudrate = baudrate;
+        self
+    }
+
+    pub fn parity_none(mut self) -> Self {
+        self.parity = Parity::ParityNone;
+        self
+    }
+
+    /// Enables Even Parity
+    ///
+    /// Note that parity bits are included in the serial word length, so if parity is used word length will be set
+    /// to 9.
+    pub fn parity_even(mut self) -> Self {
+        self.parity = Parity::ParityEven;
+        self
+    }
+
+    /// Enables Odd Parity
+    ///
+    /// Note that parity bits are included in the serial word length, so if parity is used word length will be set
+    /// to 9.
+    pub fn parity_odd(mut self) -> Self {
+        self.parity = Parity::ParityOdd;
+        self
+    }
+
+    /// Specify the number of stop bits
+    pub fn stop_bits(mut self, stopbits: StopBits) -> Self {
+        self.stop_bits = stopbits;
+        self
+    }
+    /// Specify the bit order
+    pub fn bit_order(mut self, bitorder: BitOrder) -> Self {
+        self.bit_order = bitorder;
+        self
+    }
+    /// Specify the clock phase. Only applies to USART peripherals
+    pub fn clock_phase(mut self, clockphase: ClockPhase) -> Self {
+        self.clock_phase = clockphase;
+        self
+    }
+    /// Specify the clock polarity. Only applies to USART peripherals
+    pub fn clock_polarity(mut self, clockpolarity: ClockPolarity) -> Self {
+        self.clock_polarity = clockpolarity;
+        self
+    }
+    /// Specify if the last bit transmitted in each word has a corresponding
+    /// clock pulse in the SCLK pin. Only applies to USART peripherals
+    pub fn last_bit_clock_pulse(mut self, lastbitclockpulse: bool) -> Self {
+        self.last_bit_clock_pulse = lastbitclockpulse;
+        self
+    }
+
+    /// If `true`, swap the Tx and Rx pins
+    pub fn swap_txrx(mut self, swaptxrx: bool) -> Self {
+        self.swap_txrx = swaptxrx;
+        self
+    }
+
+    /// If `true`, RX pin signal levels are inverted
+    pub fn invert_rx(mut self, invertrx: bool) -> Self {
+        self.invert_rx = invertrx;
+        self
+    }
+
+    /// If `true`, TX pin signal levels are inverted
+    pub fn invert_tx(mut self, inverttx: bool) -> Self {
+        self.invert_tx = inverttx;
+        self
+    }
+
+    pub fn rx_fifo_threshold(mut self, rxfifothreshold: FifoThreshold) -> Self {
+        self.rx_fifo_threshold = rxfifothreshold;
+        self
+    }
+
+    pub fn tx_fifo_threshold(mut self, txfifothreshold: FifoThreshold) -> Self {
+        self.tx_fifo_threshold = txfifothreshold;
+        self
+    }
+
+    /// If `true`, sets to half-duplex mode
+    pub fn half_duplex(mut self, halfduplex: bool) -> Self {
+        self.half_duplex = halfduplex;
+        self
+    }
+
+    pub fn data_width(mut self, word_size: WordSize) -> Self {
+        self.word_size = word_size;
+        self
+    }
+}
+
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct InvalidConfig;
+
+impl Default for Config {
+    fn default() -> Config {
+        Self::new(Hertz::from_raw(115_200)) // 115k2 baud
+    }
+}
+
+impl From<Hertz> for Config {
+    fn from(frequency: Hertz) -> Config {
+        Self::new(frequency)
+    }
+}

--- a/src/serial/config.rs
+++ b/src/serial/config.rs
@@ -1,6 +1,7 @@
 use crate::time::Hertz;
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum FifoThreshold {
     /// Only valid for Tx Threshold
     Empty,
@@ -19,13 +20,15 @@ pub enum FifoThreshold {
 /// hardware on receive. For example, `read()` would return [`Error::Parity`](super::Error::Parity).
 ///
 /// Note that parity bits are included in the serial word length, so if parity is used word length will be set to 9.
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Parity {
     ParityNone,
     ParityEven,
     ParityOdd,
 }
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum StopBits {
     #[doc = "1 stop bit"]
     Stop1,
@@ -36,23 +39,27 @@ pub enum StopBits {
     #[doc = "1.5 stop bits"]
     Stop1p5,
 }
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum BitOrder {
     LsbFirst,
     MsbFirst,
 }
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ClockPhase {
     First,
     Second,
 }
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum ClockPolarity {
     IdleHigh,
     IdleLow,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum WordSize {
     DataBits7,
     DataBits8,
@@ -66,7 +73,8 @@ pub enum WordSize {
 /// ```
 /// let config = Config::new().partity_odd();
 /// ```
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Config {
     pub baudrate: Hertz,
     pub parity: Parity,

--- a/src/serial/config.rs
+++ b/src/serial/config.rs
@@ -102,7 +102,7 @@ impl Config {
             invert_rx: false,
             invert_tx: false,
             rx_fifo_threshold: FifoThreshold::Eighth,
-            tx_fifo_threshold: FifoThreshold::Eighth,
+            tx_fifo_threshold: FifoThreshold::SevenEighth,
             half_duplex: false,
             word_size: WordSize::DataBits8,
         }

--- a/src/serial/usart.rs
+++ b/src/serial/usart.rs
@@ -1,0 +1,800 @@
+//! USART implementation for Serial
+//!
+//! This provides an implementation of the Serial functionality via the USART peripheral. See the
+//! documentation for the `serial` module for more information.
+
+use super::config::WordSize;
+use super::*;
+
+use core::cell::UnsafeCell;
+use core::marker::PhantomData;
+use core::ops::{Deref, DerefMut};
+use core::ptr;
+
+use embedded_io as io;
+#[cfg(feature = "log")]
+use log::debug;
+
+use crate::gpio::{self, Alternate};
+use crate::rcc::{rec, CoreClocks, ResetEnable};
+use crate::stm32::{
+    rcc::ccipr1,
+    usart1,
+    usart1::cr1::{M0, M1, PCE, PS},
+    usart1::cr3::{RXFTCFG, TXFTCFG},
+    usart1::presc::PRESCALER,
+    RCC, USART1, USART2, USART3,
+};
+
+use crate::time::Hertz;
+
+pub trait Pins<USART> {
+    const SYNCHRONOUS: bool = false;
+}
+pub trait PinTx<USART> {}
+pub trait PinRx<USART> {}
+pub trait PinCk<USART> {}
+
+impl<USART, TX, RX> Pins<USART> for (TX, RX)
+where
+    TX: PinTx<USART>,
+    RX: PinRx<USART>,
+{
+}
+
+impl<USART, TX, RX, CK> Pins<USART> for (TX, RX, CK)
+where
+    TX: PinTx<USART>,
+    RX: PinRx<USART>,
+    CK: PinCk<USART>,
+{
+    const SYNCHRONOUS: bool = true;
+}
+
+/// A filler type for when the Tx pin is unnecessary
+pub struct NoTx;
+/// A filler type for when the Rx pin is unnecessary
+pub struct NoRx;
+/// A filler type for when the Ck pin is unnecessary
+pub struct NoCk;
+
+macro_rules! usart_pins {
+    ($($USARTX:ty: TX: [$($TX:ty),*] RX: [$($RX:ty),*] CK: [$($CK:ty),*])+) => {
+        $(
+            $(
+                impl PinTx<$USARTX> for $TX {}
+            )*
+            $(
+                impl PinRx<$USARTX> for $RX {}
+            )*
+            $(
+                impl PinCk<$USARTX> for $CK {}
+            )*
+        )+
+    }
+}
+
+usart_pins! {
+    USART1:
+        TX: [
+            NoTx,
+            gpio::PA2<Alternate<8>>,
+            gpio::PA9<Alternate<7>>,
+            gpio::PA12<Alternate<8>>,
+            gpio::PA14<Alternate<7>>,
+            gpio::PB6<Alternate<7>>,
+            gpio::PB14<Alternate<4>>
+        ]
+        RX: [
+            NoRx,
+            gpio::PA1<Alternate<8>>,
+            gpio::PA10<Alternate<7>>,
+            gpio::PA11<Alternate<8>>,
+            gpio::PA13<Alternate<7>>,
+            gpio::PB7<Alternate<7>>,
+            gpio::PB15<Alternate<4>>
+        ]
+        CK: [
+            NoCk,
+            gpio::PA3<Alternate<8>>,
+            gpio::PA8<Alternate<7>>,
+            gpio::PB8<Alternate<7>>,
+            gpio::PB12<Alternate<8>>
+        ]
+    USART2:
+        TX: [
+            NoTx,
+            gpio::PA2<Alternate<7>>,
+            gpio::PA5<Alternate<9>>,
+            gpio::PA8<Alternate<4>>,
+            gpio::PA12<Alternate<4>>,
+            gpio::PA14<Alternate<9>>,
+            gpio::PB0<Alternate<9>>,
+            gpio::PB4<Alternate<13>>,
+            gpio::PC6<Alternate<13>>
+        ]
+        RX: [
+            NoRx,
+            gpio::PA3<Alternate<7>>,
+            gpio::PA11<Alternate<4>>,
+            gpio::PA13<Alternate<9>>,
+            gpio::PA15<Alternate<9>>,
+            gpio::PB1<Alternate<9>>,
+            gpio::PB5<Alternate<13>>,
+            gpio::PB15<Alternate<13>>,
+            gpio::PC7<Alternate<13>>
+        ]
+        CK: [
+            NoCk,
+            gpio::PA4<Alternate<7>>,
+            gpio::PA15<Alternate<4>>,
+            gpio::PA1<Alternate<9>>,
+            gpio::PB2<Alternate<9>>,
+            gpio::PB6<Alternate<13>>,
+            gpio::PC8<Alternate<13>>
+        ]
+    USART3:
+        TX: [
+            NoTx,
+            gpio::PB10<Alternate<7>>,
+            gpio::PC10<Alternate<7>>,
+            gpio::PA4<Alternate<13>>,
+            gpio::PA8<Alternate<13>>,
+            gpio::PB3<Alternate<13>>,
+            gpio::PB7<Alternate<13>>
+        ]
+        RX: [
+            NoRx,
+            gpio::PC4<Alternate<7>>,
+            gpio::PC11<Alternate<7>>,
+            gpio::PA3<Alternate<13>>,
+            gpio::PA5<Alternate<13>>,
+            gpio::PA12<Alternate<13>>,
+            gpio::PA15<Alternate<13>>,
+            gpio::PB8<Alternate<13>>
+        ]
+        CK: [
+            NoCk,
+            gpio::PB12<Alternate<7>>,
+            gpio::PC12<Alternate<7>>,
+            gpio::PA0<Alternate<13>>,
+            gpio::PA7<Alternate<13>>,
+            gpio::PA9<Alternate<13>>,
+            gpio::PB10<Alternate<13>>
+        ]
+}
+
+pub trait Instance:
+    crate::Sealed + Deref<Target = usart1::RegisterBlock>
+{
+    type Rec: ResetEnable;
+
+    #[doc(hidden)]
+    fn ptr() -> *const usart1::RegisterBlock;
+
+    #[doc(hidden)]
+    fn clock(clocks: &CoreClocks) -> Hertz;
+
+    #[doc(hidden)]
+    fn rec() -> Self::Rec;
+}
+
+// Implemented by all USART instances
+macro_rules! instance {
+    ($USARTX:ident: $UsartX:ident, $pclk:ident, $cciprX:ident) => {
+        paste::item! {
+            impl Instance for $USARTX {
+                type Rec = rec::$UsartX;
+
+                fn ptr() -> *const usart1::RegisterBlock {
+                    <$USARTX>::ptr() as *const _
+                }
+
+                fn clock(clocks: &CoreClocks) -> Hertz {
+                    let ccipr1 = unsafe { (*RCC::ptr()).ccipr1().read() };
+
+                    match ccipr1.[<$USARTX:lower sel>]().variant() {
+                        Some($cciprX::USARTSEL::Pclk) => Some(clocks.$pclk()),
+                        Some($cciprX::USARTSEL::Pll2Q) => clocks.pll2().q_ck(),
+                        Some($cciprX::USARTSEL::HsiKer) => clocks.hsi_ck(),
+                        Some($cciprX::USARTSEL::CsiKer) => clocks.csi_ck(),
+                        Some($cciprX::USARTSEL::Lse) => clocks.lse_ck(),
+                        _ => unreachable!(),
+                    }.expect("Source clock not enabled")
+                }
+
+                fn rec() -> Self::Rec {
+                    rec::$UsartX { _marker: PhantomData }
+                }
+            }
+
+            impl crate::Sealed for $USARTX {}
+        }
+    };
+}
+
+instance! { USART1: Usart1, pclk2, ccipr1 }
+instance! { USART2: Usart2, pclk1, ccipr1 }
+instance! { USART3: Usart3, pclk1, ccipr1 }
+
+/// Serial abstraction
+pub struct Serial<USART, W: WordBits = u8> {
+    inner: Inner<USART, W>,
+}
+
+pub struct Inner<USART, W: WordBits = u8> {
+    usart: USART,
+    _word: PhantomData<W>,
+}
+
+impl<USART, W: WordBits> Deref for Serial<USART, W> {
+    type Target = Inner<USART, W>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<USART, W: WordBits> DerefMut for Serial<USART, W> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+pub trait SerialExt<USART: Instance, W: WordBits = u8>: Sized {
+    fn serial<P: Pins<USART>>(
+        self,
+        _pins: P,
+        config: impl Into<config::Config>,
+        rec: USART::Rec,
+        clocks: &CoreClocks,
+    ) -> Result<Serial<USART, W>, config::InvalidConfig>;
+
+    fn serial_unchecked(
+        self,
+        config: impl Into<config::Config>,
+        rec: USART::Rec,
+        clocks: &CoreClocks,
+        synchronous: bool,
+    ) -> Result<Serial<USART, W>, config::InvalidConfig>;
+}
+
+impl<USART: Instance, W: WordBits> SerialExt<USART, W> for USART {
+    fn serial<P: Pins<USART>>(
+        self,
+        _pins: P,
+        config: impl Into<config::Config>,
+        rec: USART::Rec,
+        clocks: &CoreClocks,
+    ) -> Result<Serial<USART, W>, config::InvalidConfig> {
+        Serial::new(self, config, rec, clocks, P::SYNCHRONOUS)
+    }
+
+    fn serial_unchecked(
+        self,
+        config: impl Into<config::Config>,
+        rec: <USART as Instance>::Rec,
+        clocks: &CoreClocks,
+        synchronous: bool,
+    ) -> Result<Serial<USART, W>, config::InvalidConfig> {
+        Serial::new(self, config, rec, clocks, synchronous)
+    }
+}
+
+impl<USART: Instance, W: WordBits> Serial<USART, W> {
+    fn new(
+        usart: USART,
+        config: impl Into<config::Config>,
+        rec: USART::Rec,
+        clocks: &CoreClocks,
+        synchronous: bool,
+    ) -> Result<Self, config::InvalidConfig> {
+        // Enable clock for USART and reset
+        rec.enable().reset();
+
+        let mut serial = Serial {
+            inner: Inner::new(usart),
+        };
+        let config = config.into();
+        serial.usart.cr1().reset();
+
+        // Ensure that word size in config matches the word size type, W
+        if config.word_size == WordSize::DataBits9 && W::BITS < 9 {
+            return Err(config::InvalidConfig);
+        }
+        if config.word_size != WordSize::DataBits9 && W::BITS > 8 {
+            return Err(config::InvalidConfig);
+        }
+
+        // If synchronous mode is supported, check that it is not
+        // enabled alongside half duplex mode
+        if config.half_duplex & synchronous {
+            return Err(config::InvalidConfig);
+        }
+
+        let ker_ck = USART::clock(clocks);
+        serial.configure(&config, ker_ck, synchronous)?;
+
+        Ok(serial)
+    }
+
+    /// Runs the serial port configuration process
+    ///
+    /// The serial port must be disabled when called.
+    fn configure(
+        &mut self,
+        config: &config::Config,
+        ker_ck: Hertz,
+        synchronous: bool,
+    ) -> Result<(), config::InvalidConfig> {
+        use self::config::*;
+
+        // If the baudrate is low enough that BRR would be greater than 65535, use a prescalar to
+        // divide down the kernel clock frequency by a power of 2.
+        let mut div = ker_ck / config.baudrate;
+        div >>= u16::BITS;
+        let (div, presc) = match div {
+            0 => (1, PRESCALER::Div1),
+            1 => (2, PRESCALER::Div2),
+            2..=3 => (4, PRESCALER::Div4),
+            4..=5 => (6, PRESCALER::Div6),
+            6..=7 => (8, PRESCALER::Div8),
+            8..=9 => (10, PRESCALER::Div10),
+            10..=11 => (12, PRESCALER::Div12),
+            12..=15 => (16, PRESCALER::Div16),
+            16..=31 => (32, PRESCALER::Div32),
+            32..=63 => (64, PRESCALER::Div64),
+            64..=127 => (128, PRESCALER::Div128),
+            _ => (256, PRESCALER::Div256),
+        };
+
+        self.usart.presc().write(|w| w.prescaler().variant(presc));
+
+        let usart_ker_ck_presc = ker_ck / div;
+
+        // The frequency to calculate USARTDIV is this:
+        //
+        // (See RM0492 Rev 2 Section 36.5.8)
+        //
+        // 16 bit oversample: OVER8 = 0
+        // 8 bit oversample:  OVER8 = 1
+        //
+        // USARTDIV =        (ker_ck)
+        //            ------------------------
+        //            8 x (2 - OVER8) x (baud)
+        //
+        // BUT, the USARTDIV has 4 "fractional" bits, which effectively
+        // means that we need to "correct" the equation as follows:
+        //
+        // USARTDIV =      (ker_ck) * 16
+        //            ------------------------
+        //            8 x (2 - OVER8) x (baud)
+        //
+        // Calculate correct baudrate divisor on the fly
+        let (over8, usartdiv) = if (usart_ker_ck_presc / 16) >= config.baudrate
+        {
+            // We have the ability to oversample to 16 bits, take
+            // advantage of it.
+
+            let div =
+                (usart_ker_ck_presc + (config.baudrate / 2)) / config.baudrate;
+            (false, div)
+        } else if (usart_ker_ck_presc / 8) >= config.baudrate {
+            // We are close enough to pclk where we can only
+            // oversample 8.
+            let div = ((usart_ker_ck_presc * 2) + (config.baudrate / 2))
+                / config.baudrate;
+
+            // Shift USARTDIV[3:0] right by 1 when oversampling by 8
+            let frac = div & 0xF;
+            let div = (div & !0xF) | (frac >> 1);
+            (true, div)
+        } else {
+            return Err(config::InvalidConfig);
+        };
+
+        #[cfg(feature = "log")]
+        {
+            let baudrate = usart_ker_ck_presc / usartdiv;
+            debug!("USART: Kernel clock: {ker_ck}; Prescalar: {div}; Over8: {over8}; BRR: {usartdiv:#X}; Baudrate: {baudrate}");
+        }
+
+        // Calculate baudrate divisor
+
+        // 16 times oversampling, OVER8 = 0
+        let brr = usartdiv as u16;
+        self.usart.brr().write(|w| w.brr().set(brr));
+
+        // Reset registers to disable advanced USART features
+        self.usart.cr2().reset();
+        self.usart.cr3().reset();
+
+        // RXFIFO threshold
+        let fifo_threshold = match config.rx_fifo_threshold {
+            FifoThreshold::Eighth => RXFTCFG::Depth1_8,
+            FifoThreshold::Quarter => RXFTCFG::Depth1_4,
+            FifoThreshold::Half => RXFTCFG::Depth1_2,
+            FifoThreshold::ThreeQuarter => RXFTCFG::Depth3_4,
+            FifoThreshold::SevenEighth => RXFTCFG::Depth7_8,
+            FifoThreshold::Full => RXFTCFG::Full,
+            // Empty is not a valid configuration
+            _ => return Err(config::InvalidConfig),
+        };
+        self.usart
+            .cr3()
+            .modify(|_, w| w.rxftcfg().variant(fifo_threshold));
+
+        // TXFIFO threashold
+        let fifo_threshold = match config.tx_fifo_threshold {
+            FifoThreshold::Empty => TXFTCFG::Empty,
+            FifoThreshold::Eighth => TXFTCFG::Depth1_8,
+            FifoThreshold::Quarter => TXFTCFG::Depth1_4,
+            FifoThreshold::Half => TXFTCFG::Depth1_2,
+            FifoThreshold::ThreeQuarter => TXFTCFG::Depth3_4,
+            FifoThreshold::SevenEighth => TXFTCFG::Depth7_8,
+            // Full is not a valid configuration
+            _ => return Err(config::InvalidConfig),
+        };
+        self.usart
+            .cr3()
+            .modify(|_, w| w.txftcfg().variant(fifo_threshold));
+
+        // Configure half-duplex mode
+        self.usart.cr3().modify(|_, w| {
+            if config.half_duplex {
+                w.hdsel().selected()
+            } else {
+                w.hdsel().not_selected()
+            }
+        });
+
+        // Configure serial mode
+        self.usart.cr2().write(|w| {
+            match config.stop_bits {
+                StopBits::Stop0p5 => w.stop().stop0p5(),
+                StopBits::Stop1 => w.stop().stop1(),
+                StopBits::Stop1p5 => w.stop().stop1p5(),
+                StopBits::Stop2 => w.stop().stop2(),
+            };
+
+            match config.bit_order {
+                BitOrder::LsbFirst => w.msbfirst().lsb(),
+                BitOrder::MsbFirst => w.msbfirst().msb(),
+            };
+
+            if config.swap_txrx {
+                w.swap().swapped()
+            } else {
+                w.swap().standard()
+            };
+
+            if config.invert_rx {
+                w.rxinv().inverted()
+            } else {
+                w.rxinv().standard()
+            };
+
+            if config.invert_tx {
+                w.txinv().inverted()
+            } else {
+                w.txinv().standard()
+            };
+
+            if synchronous {
+                w.clken().enabled();
+
+                if config.last_bit_clock_pulse {
+                    w.lbcl().output()
+                }else {
+                    w.lbcl().not_output()
+                };
+
+                match config.clock_polarity {
+                    ClockPolarity::IdleHigh => w.cpol().high(),
+                    ClockPolarity::IdleLow => w.cpol().low(),
+                };
+
+                match config.clock_phase {
+                    ClockPhase::First => w.cpha().first(),
+                    ClockPhase::Second => w.cpha().second(),
+                };
+
+            } else {
+                w.clken().disabled();
+            }
+
+            w
+        });
+
+        // Enable transmission and receiving and configure frame
+        // Retain enabled events
+        self.usart.cr1().modify(|_, w| {
+            w.fifoen()
+                .enabled() // FIFO mode enabled
+                .over8()
+                .bit(over8)
+                .ue()
+                .enabled()
+                .te()
+                .enabled()
+                .re()
+                .enabled()
+                .m1()
+                .variant(match config.word_size {
+                    WordSize::DataBits7 => M1::Bit7,
+                    _ => M1::M0,
+                })
+                .m0()
+                .variant(match config.word_size {
+                    WordSize::DataBits9 => M0::Bit9,
+                    _ => M0::Bit8,
+                })
+                .pce()
+                .variant(match config.parity {
+                    Parity::ParityNone => PCE::Disabled,
+                    _ => PCE::Enabled,
+                })
+                .ps()
+                .variant(match config.parity {
+                    Parity::ParityOdd => PS::Odd,
+                    _ => PS::Even,
+                })
+        });
+
+        Ok(())
+    }
+
+    /// Releases the USART peripheral
+    pub fn free(self) -> USART {
+        // Wait until both TXFIFO and shift register are empty
+        while self.usart.isr().read().tc().bit_is_clear() {}
+
+        self.inner.usart
+    }
+
+    /// Returns a reference to the inner peripheral
+    pub fn inner(&self) -> &USART {
+        &self.usart
+    }
+
+    /// Returns a mutable reference to the inner peripheral
+    pub fn inner_mut(&mut self) -> &mut USART {
+        &mut self.usart
+    }
+}
+
+impl<USART, W: WordBits> Inner<USART, W> {
+    fn new(usart: USART) -> Self {
+        Inner {
+            usart,
+            _word: PhantomData,
+        }
+    }
+}
+
+macro_rules! check_status_error {
+    ($isr:expr) => {
+        if $isr.pe().bit_is_set() {
+            Err(Error::Parity)
+        } else if $isr.fe().bit_is_set() {
+            Err(Error::Framing)
+        } else if $isr.ne().bit_is_set() {
+            Err(Error::Noise)
+        } else if $isr.ore().bit_is_set() {
+            Err(Error::Overrun)
+        } else {
+            Ok(())
+        }
+    };
+}
+
+impl<USART: Instance, W: WordBits> Inner<USART, W> {
+    /// Starts listening for an interrupt event
+    pub fn listen(&mut self, event: Event) {
+        match event {
+            Event::RxNotEmpty => {
+                self.usart.cr1().modify(|_, w| w.rxneie().enabled());
+            }
+            Event::TxNotFull => {
+                self.usart.cr1().modify(|_, w| w.txeie().enabled());
+            }
+            Event::Idle => {
+                self.usart.cr1().modify(|_, w| w.idleie().enabled());
+            }
+            Event::TxFifoThreshold => {
+                self.usart.cr3().modify(|_, w| w.txftie().set_bit());
+            }
+            Event::RxFifoThreshold => {
+                self.usart.cr3().modify(|_, w| w.rxftie().set_bit());
+            }
+        }
+    }
+
+    /// Stop listening for an interrupt event
+    pub fn unlisten(&mut self, event: Event) {
+        match event {
+            Event::RxNotEmpty => {
+                self.usart.cr1().modify(|_, w| w.rxneie().disabled());
+            }
+            Event::TxNotFull => {
+                self.usart.cr1().modify(|_, w| w.txeie().disabled());
+            }
+            Event::Idle => {
+                self.usart.cr1().modify(|_, w| w.idleie().disabled());
+            }
+            Event::TxFifoThreshold => {
+                self.usart.cr3().modify(|_, w| w.txftie().clear_bit());
+            }
+            Event::RxFifoThreshold => {
+                self.usart.cr3().modify(|_, w| w.rxftie().clear_bit());
+            }
+        }
+        let _ = self.usart.cr1().read();
+        let _ = self.usart.cr1().read(); // Delay 2 peripheral clocks
+    }
+
+    /// Return true if the line idle status is set
+    ///
+    /// The line idle status bit is set when the peripheral detects the receive line is idle.
+    /// The bit is cleared by software, by calling `clear_idle()`.
+    pub fn is_idle(&self) -> bool {
+        self.usart.isr().read().idle().bit_is_set()
+    }
+
+    /// Clear the line idle status bit
+    pub fn clear_idle(&mut self) {
+        self.usart.icr().write(|w| w.idlecf().clear());
+        let _ = self.usart.isr().read();
+        let _ = self.usart.isr().read(); // Delay 2 peripheral clocks
+    }
+
+    /// Return true if the line busy status is set
+    ///
+    /// The busy status bit is set when there is communication active on the receive line,
+    /// and reset at the end of reception.
+    pub fn is_busy(&self) -> bool {
+        self.usart.isr().read().busy().bit_is_set()
+    }
+
+    /// Return true if the tx register is empty (and can accept data)
+    fn is_txe(&self) -> bool {
+        self.usart.isr().read().txfe().bit_is_set()
+    }
+
+    /// Return true if the rx register is not empty (and can be read)
+    fn is_rxne(&mut self) -> Result<bool, Error> {
+        let isr = self.usart.isr().read();
+
+        match check_status_error!(isr) {
+            Ok(()) => {}
+            Err(error) => {
+                self.clear_error_flag(error);
+                return Err(error);
+            }
+        };
+
+        Ok(isr.rxfne().bit_is_set())
+    }
+
+    fn read_data(&mut self) -> W {
+        // NOTE(read_volatile) see `write_volatile` below
+        unsafe { ptr::read_volatile(self.usart.rdr() as *const _ as *const W) }
+    }
+
+    fn write_data(&mut self, word: W) {
+        // NOTE(unsafe) atomic write to stateless register
+        // NOTE(write_volatile) 8- or 16-bit write that's not possible through the svd2rust API
+        unsafe {
+            let tdr = self.usart.tdr() as *const _ as *const UnsafeCell<W>;
+            ptr::write_volatile(UnsafeCell::raw_get(tdr), word);
+        }
+    }
+
+    fn clear_error_flag(&mut self, error: Error) {
+        match error {
+            Error::Framing => self.usart.icr().write(|w| w.fecf().clear()),
+            Error::Noise => self.usart.icr().write(|w| w.necf().clear()),
+            Error::Overrun => self.usart.icr().write(|w| w.orecf().clear()),
+            Error::Parity => self.usart.icr().write(|w| w.pecf().clear()),
+        };
+    }
+
+    fn read_if_ready(&mut self, word: &mut W) -> Result<bool, Error> {
+        let isr = self.usart.isr().read();
+
+        match check_status_error!(isr) {
+            Ok(()) => {}
+            Err(error) => {
+                self.clear_error_flag(error);
+                return Err(error);
+            }
+        };
+
+        if isr.rxfne().bit_is_set() {
+            *word = self.read_data();
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write_if_ready(&mut self, word: W) -> Result<bool, Error> {
+        if self.usart.isr().read().txfnf().bit_is_set() {
+            self.write_data(word);
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn is_transmit_complete(&mut self) -> bool {
+        self.usart.isr().read().tc().bit_is_set()
+    }
+
+    fn read_words(&mut self, words: &mut [W]) -> Result<usize, Error> {
+        for (i, w) in words.iter_mut().enumerate() {
+            if !self.read_if_ready(w)? {
+                return Ok(i);
+            }
+        }
+        Ok(words.len())
+    }
+
+    fn write_words(&mut self, words: &[W]) -> Result<usize, Error> {
+        for (i, w) in words.iter().enumerate() {
+            if !self.write_if_ready(*w)? {
+                return Ok(i);
+            }
+        }
+        Ok(words.len())
+    }
+}
+
+/*
+ *  HAL Implementations
+ */
+
+impl<USART, W: WordBits> io::ErrorType for Serial<USART, W> {
+    type Error = Error;
+}
+
+impl<USART: Instance> io::Read for Serial<USART, u8> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        let count = loop {
+            let count = self.read_words(buf)?;
+            if count > 0 {
+                break count;
+            }
+        };
+        Ok(count)
+    }
+}
+
+impl<USART: Instance> io::ReadReady for Serial<USART, u8> {
+    fn read_ready(&mut self) -> Result<bool, Self::Error> {
+        self.is_rxne()
+    }
+}
+
+impl<USART: Instance> io::Write for Serial<USART, u8> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        let count = loop {
+            let count = self.write_words(buf)?;
+            if count > 0 {
+                break count;
+            }
+        };
+        Ok(count)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        while !self.is_transmit_complete() {}
+        Ok(())
+    }
+}
+
+impl<USART: Instance> io::WriteReady for Serial<USART, u8> {
+    fn write_ready(&mut self) -> Result<bool, Self::Error> {
+        Ok(self.is_txe())
+    }
+}

--- a/src/serial/usart.rs
+++ b/src/serial/usart.rs
@@ -11,6 +11,8 @@ use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut};
 use core::ptr;
 
+#[cfg(feature = "defmt")]
+use defmt::debug;
 use embedded_io as io;
 #[cfg(feature = "log")]
 use log::debug;
@@ -248,10 +250,12 @@ impl<USART: Instance, W: WordBits> Serial<USART, W> {
             return Err(config::InvalidConfig);
         };
 
-        #[cfg(feature = "log")]
+        #[cfg(any(feature = "log", feature = "defmt"))]
         {
             let baudrate = usart_ker_ck_presc / usartdiv;
-            debug!("USART: Kernel clock: {ker_ck}; Prescalar: {div}; Over8: {over8}; BRR: {usartdiv:#X}; Baudrate: {baudrate}");
+            debug!("USART: Kernel clock: {}; Prescalar: {}; Over8: {}; BRR: {:#X}; Baudrate: {}",
+                   ker_ck, div, over8, usartdiv, baudrate
+            );
         }
 
         // Calculate baudrate divisor

--- a/src/serial/usart/usart_def.rs
+++ b/src/serial/usart/usart_def.rs
@@ -302,9 +302,9 @@ mod rm0481_common {
 
 #[cfg(feature = "h56x_h573")]
 mod h56x_h573 {
-    use stm32h5::stm32h573::rcc::ccipr2;
-
-    use crate::stm32::{UART12, UART7, UART8, UART9, USART10, USART11};
+    use crate::stm32::{
+        rcc::ccipr2, UART12, UART7, UART8, UART9, USART10, USART11,
+    };
 
     use super::*;
 

--- a/src/serial/usart/usart_def.rs
+++ b/src/serial/usart/usart_def.rs
@@ -1,0 +1,415 @@
+use core::marker::PhantomData;
+
+use crate::gpio::{self, Alternate};
+use crate::rcc::{rec, CoreClocks};
+use crate::stm32::{rcc::ccipr1, usart1, RCC, USART1, USART2, USART3};
+use crate::time::Hertz;
+
+use super::{Instance, InstanceClock, NoCk, NoRx, NoTx, PinCk, PinRx, PinTx};
+
+macro_rules! usart_pins {
+    ($($USARTX:ty: TX: [$($TX:ty),*] RX: [$($RX:ty),*] CK: [$($CK:ty),*])+) => {
+        $(
+            $(
+                impl PinTx<$USARTX> for $TX {}
+            )*
+            $(
+                impl PinRx<$USARTX> for $RX {}
+            )*
+            $(
+                impl PinCk<$USARTX> for $CK {}
+            )*
+        )+
+    }
+}
+
+macro_rules! instance_clock {
+    ($USARTX:ident: $pclk:ident, $cciprX:ident [$($pll:ident:$pll_clk:ident),+] [$($clk:ident$(:$ext:ident)?),*]) => { paste::item! {
+        impl InstanceClock for $USARTX {
+            fn clock(clocks: &CoreClocks) -> Hertz {
+                let $cciprX = unsafe { (*RCC::ptr()).$cciprX().read() };
+
+                match $cciprX.[<$USARTX:lower sel>]().variant() {
+                    Some($cciprX::USARTSEL::Pclk) => Some(clocks.$pclk()),
+                    $(
+                        Some($cciprX::USARTSEL::[<$pll:camel $pll_clk:upper>]) => clocks.[< $pll:lower >]().[< $pll_clk:lower:snake _ck >](),
+                    )+
+                    $(
+                        Some($cciprX::USARTSEL::[<$clk:camel $($ext)?>]) => clocks.[< $clk:lower _ck >](),
+                    )*
+                    _ => unreachable!(),
+                }.expect("Source clock not enabled")
+            }
+        }
+    }}
+}
+
+// Implemented by all USART instances
+macro_rules! instances {
+    ($($USARTX:ident),+) => { paste::item! {
+        $(
+            impl Instance for $USARTX {
+                type Rec = rec::[<$USARTX:camel>];
+
+                fn ptr() -> *const usart1::RegisterBlock {
+                    <$USARTX>::ptr() as *const _
+                }
+
+                fn rec() -> Self::Rec {
+                    rec::[< $USARTX:camel >] { _marker: PhantomData }
+                }
+            }
+
+            impl crate::Sealed for $USARTX {}
+        )+
+    }};
+}
+
+instances!(USART1, USART2, USART3);
+
+#[cfg(feature = "rm0492")]
+mod rm492 {
+    use super::*;
+
+    instance_clock!(USART1: pclk2, ccipr1 [Pll2:Q] [Hsi:Ker, Csi:Ker, Lse]);
+    instance_clock!(USART2: pclk1, ccipr1 [Pll2:Q] [Hsi:Ker, Csi:Ker, Lse]);
+    instance_clock!(USART3: pclk1, ccipr1 [Pll2:Q] [Hsi:Ker, Csi:Ker, Lse]);
+
+    usart_pins! {
+        USART1:
+            TX: [
+                NoTx,
+                gpio::PA2<Alternate<8>>,
+                gpio::PA9<Alternate<7>>,
+                gpio::PA12<Alternate<8>>,
+                gpio::PA14<Alternate<7>>,
+                gpio::PB6<Alternate<7>>,
+                gpio::PB14<Alternate<4>>
+            ]
+            RX: [
+                NoRx,
+                gpio::PA1<Alternate<8>>,
+                gpio::PA10<Alternate<7>>,
+                gpio::PA11<Alternate<8>>,
+                gpio::PA13<Alternate<7>>,
+                gpio::PB7<Alternate<7>>,
+                gpio::PB15<Alternate<4>>
+            ]
+            CK: [
+                NoCk,
+                gpio::PA3<Alternate<8>>,
+                gpio::PA8<Alternate<7>>,
+                gpio::PB8<Alternate<7>>,
+                gpio::PB12<Alternate<8>>
+            ]
+        USART2:
+            TX: [
+                NoTx,
+                gpio::PA2<Alternate<7>>,
+                gpio::PA5<Alternate<9>>,
+                gpio::PA8<Alternate<4>>,
+                gpio::PA12<Alternate<4>>,
+                gpio::PA14<Alternate<9>>,
+                gpio::PB0<Alternate<9>>,
+                gpio::PB4<Alternate<13>>,
+                gpio::PC6<Alternate<13>>
+            ]
+            RX: [
+                NoRx,
+                gpio::PA3<Alternate<7>>,
+                gpio::PA11<Alternate<4>>,
+                gpio::PA13<Alternate<9>>,
+                gpio::PA15<Alternate<9>>,
+                gpio::PB1<Alternate<9>>,
+                gpio::PB5<Alternate<13>>,
+                gpio::PB15<Alternate<13>>,
+                gpio::PC7<Alternate<13>>
+            ]
+            CK: [
+                NoCk,
+                gpio::PA4<Alternate<7>>,
+                gpio::PA15<Alternate<4>>,
+                gpio::PA1<Alternate<9>>,
+                gpio::PB2<Alternate<9>>,
+                gpio::PB6<Alternate<13>>,
+                gpio::PC8<Alternate<13>>
+            ]
+        USART3:
+            TX: [
+                NoTx,
+                gpio::PB10<Alternate<7>>,
+                gpio::PC10<Alternate<7>>,
+                gpio::PA4<Alternate<13>>,
+                gpio::PA8<Alternate<13>>,
+                gpio::PB3<Alternate<13>>,
+                gpio::PB7<Alternate<13>>
+            ]
+            RX: [
+                NoRx,
+                gpio::PC4<Alternate<7>>,
+                gpio::PC11<Alternate<7>>,
+                gpio::PA3<Alternate<13>>,
+                gpio::PA5<Alternate<13>>,
+                gpio::PA12<Alternate<13>>,
+                gpio::PA15<Alternate<13>>,
+                gpio::PB8<Alternate<13>>
+            ]
+            CK: [
+                NoCk,
+                gpio::PB12<Alternate<7>>,
+                gpio::PC12<Alternate<7>>,
+                gpio::PA0<Alternate<13>>,
+                gpio::PA7<Alternate<13>>,
+                gpio::PA9<Alternate<13>>,
+                gpio::PB10<Alternate<13>>
+            ]
+    }
+}
+
+// Note: pin data is taken from stm32h56x, stm32h573, stm32h523 and stm32h533 datasheets
+#[cfg(feature = "rm0481")]
+mod rm0481_common {
+    use crate::stm32::{UART4, UART5, USART6};
+
+    use super::*;
+
+    instance_clock!(USART1: pclk2, ccipr1 [Pll2:Q, Pll3:Q] [Hsi:Ker, Csi:Ker, Lse]);
+    instance_clock!(USART2: pclk1, ccipr1 [Pll2:Q, Pll3:Q] [Hsi:Ker, Csi:Ker, Lse]);
+    instance_clock!(USART3: pclk1, ccipr1 [Pll2:Q, Pll3:Q] [Hsi:Ker, Csi:Ker, Lse]);
+    instance_clock!(UART4: pclk1, ccipr1 [Pll2:Q, Pll3:Q] [Hsi:Ker, Csi:Ker, Lse]);
+    instance_clock!(UART5: pclk1, ccipr1 [Pll2:Q, Pll3:Q] [Hsi:Ker, Csi:Ker, Lse]);
+    instance_clock!(USART6: pclk1, ccipr1 [Pll2:Q, Pll3:Q] [Hsi:Ker, Csi:Ker, Lse]);
+
+    instances! { UART4, UART5, USART6 }
+
+    usart_pins! {
+        USART1:
+            TX: [
+                NoTx,
+                gpio::PA9<Alternate<7>>,
+                gpio::PA15<Alternate<7>>,
+                gpio::PB6<Alternate<7>>,
+                gpio::PB14<Alternate<4>>
+            ]
+            RX: [
+                NoRx,
+                gpio::PA10<Alternate<7>>,
+                gpio::PB7<Alternate<7>>,
+                gpio::PB15<Alternate<4>>
+            ]
+            CK: [
+                NoCk,
+                gpio::PA8<Alternate<7>>
+            ]
+        USART2:
+            TX: [
+                NoTx,
+                gpio::PA2<Alternate<7>>,
+                gpio::PB0<Alternate<7>>,
+                gpio::PD5<Alternate<7>>
+            ]
+            RX: [
+                NoRx,
+                gpio::PA3<Alternate<7>>,
+                gpio::PD6<Alternate<7>>
+            ]
+            CK: [
+                NoCk,
+                gpio::PA4<Alternate<7>>,
+                gpio::PD7<Alternate<7>>
+            ]
+        USART3:
+            TX: [
+                NoTx,
+                gpio::PB10<Alternate<7>>,
+                gpio::PC10<Alternate<7>>,
+                gpio::PD8<Alternate<7>>
+            ]
+            RX: [
+                NoRx,
+                gpio::PB1<Alternate<7>>,
+                gpio::PC4<Alternate<7>>,
+                gpio::PD9<Alternate<7>>,
+                gpio::PC11<Alternate<7>>
+            ]
+            CK: [
+                NoCk,
+                gpio::PB12<Alternate<7>>,
+                gpio::PC12<Alternate<7>>,
+                gpio::PD10<Alternate<13>>
+            ]
+        UART4:
+            TX: [
+                NoTx,
+                gpio::PA0<Alternate<8>>,
+                gpio::PA12<Alternate<6>>,
+                gpio::PB9<Alternate<8>>,
+                gpio::PC10<Alternate<8>>,
+                gpio::PD1<Alternate<7>>,
+                gpio::PD12<Alternate<8>>
+            ]
+            RX: [
+                NoRx,
+                gpio::PA1<Alternate<8>>,
+                gpio::PA11<Alternate<6>>,
+                gpio::PC11<Alternate<8>>,
+                gpio::PD11<Alternate<8>>,
+                gpio::PD0<Alternate<8>>,
+                gpio::PB8<Alternate<8>>
+            ]
+            CK: [
+                NoCk
+            ]
+        UART5:
+            TX: [
+                NoTx,
+                gpio::PB13<Alternate<14>>,
+                gpio::PC12<Alternate<8>>,
+                gpio::PB3<Alternate<14>>,
+                gpio::PB6<Alternate<14>>
+            ]
+            RX: [
+                NoRx,
+                gpio::PB12<Alternate<14>>,
+                gpio::PB15<Alternate<14>>,
+                gpio::PD2<Alternate<8>>,
+                gpio::PB5<Alternate<14>>
+            ]
+            CK: [
+                NoCk
+            ]
+        USART6:
+            TX: [
+                NoTx,
+                gpio::PC6<Alternate<7>>,
+                gpio::PG14<Alternate<7>>,
+                gpio::PB5<Alternate<6>>
+            ]
+            RX: [
+                NoRx,
+                gpio::PC7<Alternate<7>>,
+                gpio::PG9<Alternate<7>>,
+                gpio::PB6<Alternate<6>>
+            ]
+            CK: [
+                NoCk,
+                gpio::PA1<Alternate<14>>,
+                gpio::PG7<Alternate<7>>,
+                gpio::PC8<Alternate<7>>
+            ]
+    }
+}
+
+#[cfg(feature = "h56x_h573")]
+mod h56x_h573 {
+    use stm32h5::stm32h573::rcc::ccipr2;
+
+    use crate::stm32::{UART12, UART7, UART8, UART9, USART10, USART11};
+
+    use super::*;
+
+    instance_clock!(UART7: pclk1, ccipr1 [Pll2:Q, Pll3:Q] [Hsi:Ker, Csi:Ker, Lse]);
+    instance_clock!(UART8: pclk1, ccipr1 [Pll2:Q, Pll3:Q] [Hsi:Ker, Csi:Ker, Lse]);
+    instance_clock!(UART9: pclk1, ccipr1 [Pll2:Q, Pll3:Q] [Hsi:Ker, Csi:Ker, Lse]);
+    instance_clock!(USART10: pclk1, ccipr1 [Pll2:Q, Pll3:Q] [Hsi:Ker, Csi:Ker, Lse]);
+    instance_clock!(USART11: pclk1, ccipr2 [Pll2:Q, Pll3:Q] [Hsi:Ker, Csi:Ker, Lse]);
+    instance_clock!(UART12: pclk1, ccipr2 [Pll2:Q, Pll3:Q] [Hsi:Ker, Csi:Ker, Lse]);
+    instances!(UART7, UART8, UART9, USART10, USART11, UART12);
+
+    usart_pins! {
+        UART7:
+            TX: [
+                NoTx,
+                gpio::PF7<Alternate<7>>,
+                gpio::PE8<Alternate<7>>,
+                gpio::PA15<Alternate<11>>,
+                gpio::PB4<Alternate<11>>
+            ]
+            RX: [
+                NoRx,
+                gpio::PF6<Alternate<7>>,
+                gpio::PE7<Alternate<7>>,
+                gpio::PA8<Alternate<11>>,
+                gpio::PB3<Alternate<11>>
+            ]
+            CK: [
+                NoCk
+            ]
+        UART8:
+            TX: [
+                NoTx,
+                gpio::PE2<Alternate<8>>,
+                gpio::PH13<Alternate<7>>,
+                gpio::PE1<Alternate<8>>
+            ]
+            RX: [
+                NoRx,
+                gpio::PE0<Alternate<8>>
+            ]
+            CK: [
+                NoCk
+            ]
+        UART9:
+            TX: [
+                NoTx,
+                gpio::PG1<Alternate<11>>,
+                gpio::PD15<Alternate<11>>
+            ]
+            RX: [
+                NoRx,
+                gpio::PG0<Alternate<11>>,
+                gpio::PD14<Alternate<11>>
+            ]
+            CK: [
+                NoCk
+            ]
+        USART10:
+            TX: [
+                NoTx,
+                gpio::PE3<Alternate<7>>,
+                gpio::PG12<Alternate<6>>
+            ]
+            RX: [
+                NoRx,
+                gpio::PE2<Alternate<7>>,
+                gpio::PG11<Alternate<6>>
+            ]
+            CK: [
+                NoCk,
+                gpio::PE15<Alternate<7>>,
+                gpio::PG15<Alternate<6>>
+            ]
+        USART11:
+            TX: [
+                NoTx,
+                gpio::PF3<Alternate<7>>,
+                gpio::PA6<Alternate<7>>
+            ]
+            RX: [
+                NoRx,
+                gpio::PF4<Alternate<7>>,
+                gpio::PA7<Alternate<7>>
+            ]
+            CK: [
+                NoCk,
+                gpio::PF2<Alternate<7>>,
+                gpio::PB0<Alternate<7>>
+            ]
+        UART12:
+            TX: [
+                NoTx,
+                gpio::PF2<Alternate<6>>,
+                gpio::PE10<Alternate<6>>,
+                gpio::PG3<Alternate<7>>
+            ]
+            RX: [
+                NoRx,
+                gpio::PF5<Alternate<6>>,
+                gpio::PE9<Alternate<6>>,
+                gpio::PG2<Alternate<7>>
+            ]
+            CK: [
+                NoCk
+            ]
+    }
+}

--- a/src/serial/usart/usart_def.rs
+++ b/src/serial/usart/usart_def.rs
@@ -236,7 +236,7 @@ mod rm0481_common {
                 NoCk,
                 gpio::PB12<Alternate<7>>,
                 gpio::PC12<Alternate<7>>,
-                gpio::PD10<Alternate<13>>
+                gpio::PD10<Alternate<7>>
             ]
         UART4:
             TX: [
@@ -245,7 +245,7 @@ mod rm0481_common {
                 gpio::PA12<Alternate<6>>,
                 gpio::PB9<Alternate<8>>,
                 gpio::PC10<Alternate<8>>,
-                gpio::PD1<Alternate<7>>,
+                gpio::PD1<Alternate<8>>,
                 gpio::PD12<Alternate<8>>
             ]
             RX: [


### PR DESCRIPTION
This adds basic asynchronous serial functionality for the UART and USART peripherals on the STM32H5 family. The public API for using it is implemented using the embedded-io traits, which allows for both non-blocking and blocking operation using the trait methods.

Serial functionality for the LPUART is not implemented in this change, nor is synchronous behavior on the USART peripherals.