### PR TITLE
timer: Add basic timer operation for H5 family

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,13 +80,6 @@ log = { version = "0.4.20", optional = true}
 futures-util = { version = "0.3", default-features = false, features = ["async-await-macro"], optional = true}
 stm32-usbd = "0.8.0"
 
-##
-embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = ["unproven"] }
-nb = "1.0.0"
-void = { version = "1.0.2", default-features = false }
-cast = { version = "0.3.0", default-features = false }
-##
-
 [dev-dependencies]
 log = { version = "0.4.20"}
 cortex-m-rt = "0.7.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,10 @@ opt-level = "s" # optimize for binary size
 name = "blinky"
 
 [[example]]
+name = "blinky_timer"
+required-features = ["stm32h533"]
+
+[[example]]
 name = "i2c"
 required-features = ["stm32h503"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ name = "blinky"
 
 [[example]]
 name = "blinky_timer"
-required-features = ["stm32h533"]
+
 
 [[example]]
 name = "i2c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,13 @@ log = { version = "0.4.20", optional = true}
 futures-util = { version = "0.3", default-features = false, features = ["async-await-macro"], optional = true}
 stm32-usbd = "0.8.0"
 
+##
+embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = ["unproven"] }
+nb = "1.0.0"
+void = { version = "1.0.2", default-features = false }
+cast = { version = "0.3.0", default-features = false }
+##
+
 [dev-dependencies]
 log = { version = "0.4.20"}
 cortex-m-rt = "0.7.3"

--- a/examples/blinky_timer.rs
+++ b/examples/blinky_timer.rs
@@ -1,0 +1,84 @@
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+mod utilities;
+
+use core::{
+    cell::RefCell,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use cortex_m::interrupt::Mutex;
+use cortex_m::peripheral::NVIC;
+use cortex_m_rt::entry;
+
+use stm32h5xx_hal::gpio::gpioa::PA5; // LED pin
+use stm32h5xx_hal::gpio::{Output, PushPull};
+use stm32h5xx_hal::{pac, pac::interrupt, prelude::*, timer};
+use utilities::logger::info;
+
+static LED_IS_ON: AtomicBool = AtomicBool::new(false);
+static LED: Mutex<RefCell<Option<PA5<Output<PushPull>>>>> =
+    Mutex::new(RefCell::new(None));
+static TIMER: Mutex<RefCell<Option<timer::Timer<pac::TIM2>>>> =
+    Mutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    utilities::logger::init();
+
+    let mut cp = cortex_m::Peripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
+
+    let pwr = dp.PWR.constrain();
+    let pwrcfg = pwr.vos0().freeze();
+
+    // Constrain and Freeze clock
+    let rcc = dp.RCC.constrain();
+    let ccdr = rcc.sys_ck(250.MHz()).freeze(pwrcfg, &dp.SBS);
+
+    let gpioa = dp.GPIOA.split(ccdr.peripheral.GPIOA);
+    let mut led = gpioa.pa5.into_push_pull_output();
+    led.set_low();
+
+    let mut timer = dp.TIM2.timer(2.Hz(), ccdr.peripheral.TIM2, &ccdr.clocks);
+    timer.listen(timer::Event::TimeOut);
+
+    cortex_m::interrupt::free(|cs| {
+        LED.borrow(cs).replace(Some(led));
+        TIMER.borrow(cs).replace(Some(timer));
+    });
+
+    info!("Start blinking with timer...");
+    // Enable TIM2 interrupt
+    unsafe {
+        cp.NVIC.set_priority(interrupt::TIM2, 1);
+        NVIC::unmask::<interrupt>(interrupt::TIM2);
+    }
+
+    loop {
+        // do_nothing
+    }
+}
+
+/// Handle timer overflow
+///
+/// The interrupt should be configured at maximum priority, it won't take very long.
+#[interrupt]
+fn TIM2() {
+    cortex_m::interrupt::free(|cs| {
+        if let Some(timer) = TIMER.borrow(cs).borrow_mut().as_mut() {
+            timer.clear_irq();
+        }
+        // Signal that the interrupt fired
+        let led_is_on = LED_IS_ON.fetch_not(Ordering::Relaxed);
+        if let Some(led) = LED.borrow(cs).borrow_mut().as_mut() {
+            if led_is_on {
+                led.set_low();
+            } else {
+                led.set_high();
+            }
+        }
+    })
+}

--- a/examples/blinky_timer.rs
+++ b/examples/blinky_timer.rs
@@ -13,15 +13,19 @@ use cortex_m::interrupt::Mutex;
 use cortex_m::peripheral::NVIC;
 use cortex_m_rt::entry;
 
-use stm32h5xx_hal::gpio::gpioa::PA5; // LED pin
-use stm32h5xx_hal::gpio::{Output, PushPull};
-use stm32h5xx_hal::{pac, pac::interrupt, prelude::*, timer};
+use stm32h5xx_hal::{
+    gpio::{gpioa::PA5, Output, PushPull},
+    pac,
+    pac::interrupt,
+    prelude::*,
+    timer,
+};
 use utilities::logger::info;
 
 static LED_IS_ON: AtomicBool = AtomicBool::new(false);
 static LED: Mutex<RefCell<Option<PA5<Output<PushPull>>>>> =
     Mutex::new(RefCell::new(None));
-static TIMER: Mutex<RefCell<Option<timer::Timer<pac::TIM2>>>> =
+static TIMER: Mutex<RefCell<Option<timer::Timeout<pac::TIM2>>>> =
     Mutex::new(RefCell::new(None));
 
 #[entry]
@@ -42,8 +46,9 @@ fn main() -> ! {
     let mut led = gpioa.pa5.into_push_pull_output();
     led.set_low();
 
-    let mut timer = dp.TIM2.timer(2.Hz(), ccdr.peripheral.TIM2, &ccdr.clocks);
+    let mut timer = dp.TIM2.timeout(ccdr.peripheral.TIM2, &ccdr.clocks);
     timer.enable_timeout_interrupt();
+    timer.start_with_frequency(2.Hz());
     cortex_m::interrupt::free(|cs| {
         LED.borrow(cs).replace(Some(led));
         TIMER.borrow(cs).replace(Some(timer));
@@ -68,7 +73,7 @@ fn main() -> ! {
 fn TIM2() {
     cortex_m::interrupt::free(|cs| {
         if let Some(timer) = TIMER.borrow(cs).borrow_mut().as_mut() {
-            let _ = timer.check_clear_timeout();
+            let _ = timer.check_clear_overflow();
         }
         // Signal that the interrupt fired
         let led_is_on = LED_IS_ON.fetch_not(Ordering::Relaxed);

--- a/examples/blinky_timer.rs
+++ b/examples/blinky_timer.rs
@@ -62,7 +62,7 @@ fn main() -> ! {
     }
 
     loop {
-        // do_nothing
+        cortex_m::asm::nop();
     }
 }
 

--- a/examples/blinky_timer.rs
+++ b/examples/blinky_timer.rs
@@ -43,8 +43,7 @@ fn main() -> ! {
     led.set_low();
 
     let mut timer = dp.TIM2.timer(2.Hz(), ccdr.peripheral.TIM2, &ccdr.clocks);
-    timer.listen(timer::Event::TimeOut);
-
+    timer.enable_timeout_interrupt();
     cortex_m::interrupt::free(|cs| {
         LED.borrow(cs).replace(Some(led));
         TIMER.borrow(cs).replace(Some(timer));
@@ -69,7 +68,7 @@ fn main() -> ! {
 fn TIM2() {
     cortex_m::interrupt::free(|cs| {
         if let Some(timer) = TIMER.borrow(cs).borrow_mut().as_mut() {
-            timer.clear_irq();
+            let _ = timer.check_clear_timeout();
         }
         // Signal that the interrupt fired
         let led_is_on = LED_IS_ON.fetch_not(Ordering::Relaxed);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(non_camel_case_types)]
 
-pub use nb;
-pub use nb::block;
-
 #[cfg(not(feature = "device-selected"))]
 compile_error!(
     "This crate requires one of the following device features enabled:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(non_camel_case_types)]
 
+pub use nb;
+pub use nb::block;
+
 #[cfg(not(feature = "device-selected"))]
 compile_error!(
     "This crate requires one of the following device features enabled:
@@ -87,6 +90,9 @@ pub mod gpdma;
 
 #[cfg(feature = "device-selected")]
 pub mod serial;
+
+#[cfg(feature = "device-selected")]
+pub mod timer;
 
 #[cfg(feature = "device-selected")]
 pub mod crc;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,5 @@
 //! Prelude
+pub use embedded_hal_02::prelude::*;
 
 pub use crate::crc::CrcExt as _stm32h5xx_hal_crc_CrcExt;
 pub use crate::delay::DelayExt as _stm32h5xx_hal_delay_DelayExt;
@@ -12,6 +13,7 @@ pub use crate::rcc::RccExt as _stm32h5xx_hal_rcc_RccExt;
 pub use crate::serial::usart::SerialExt as _stm32h5xx_hal_serial_SerialExt;
 pub use crate::spi::SpiExt as _stm32h5xx_hal_spi_SpiExt;
 pub use crate::usb::UsbExt as _stm32h5xx_hal_usb_UsbExt;
+pub use crate::timer::TimerExt as _stm32h5xx_hal_timer_TimerExt;
 
 pub use crate::time::U32Ext as _;
 pub use fugit::{ExtU32 as _, RateExtU32 as _};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,4 @@
 //! Prelude
-pub use embedded_hal_02::prelude::*;
 
 pub use crate::crc::CrcExt as _stm32h5xx_hal_crc_CrcExt;
 pub use crate::delay::DelayExt as _stm32h5xx_hal_delay_DelayExt;
@@ -12,8 +11,8 @@ pub use crate::pwr::PwrExt as _stm32h5xx_hal_pwr_PwrExt;
 pub use crate::rcc::RccExt as _stm32h5xx_hal_rcc_RccExt;
 pub use crate::serial::usart::SerialExt as _stm32h5xx_hal_serial_SerialExt;
 pub use crate::spi::SpiExt as _stm32h5xx_hal_spi_SpiExt;
-pub use crate::usb::UsbExt as _stm32h5xx_hal_usb_UsbExt;
 pub use crate::timer::TimerExt as _stm32h5xx_hal_timer_TimerExt;
+pub use crate::usb::UsbExt as _stm32h5xx_hal_usb_UsbExt;
 
 pub use crate::time::U32Ext as _;
 pub use fugit::{ExtU32 as _, RateExtU32 as _};

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,0 +1,441 @@
+//! Timers
+//!
+//! # Examples
+//!
+//! - [Blinky using a Timer](https://github.com/stm32-rs/stm32h7xx-hal/blob/master/examples/blinky_timer.rs)
+//! - [64 bit microsecond timer](https://github.com/stm32-rs/stm32h7xx-hal/blob/master/examples/tick_timer.rs)
+
+// TODO: on the h7x3 at least, only TIM2, TIM3, TIM4, TIM5 can support 32 bits.
+// TIM1 is 16 bit.
+
+use core::marker::PhantomData;
+
+use crate::stm32::{TIM1, TIM2, TIM3, TIM6, TIM7};
+#[cfg(feature = "rm0481")]
+use crate::stm32::{TIM12, TIM15, TIM4, TIM5, TIM8};
+
+use cast::{u16, u32};
+use void::Void;
+
+use crate::rcc::{rec, CoreClocks, ResetEnable};
+use crate::time::Hertz;
+
+/// Associate clocks with timers
+pub trait GetClk {
+    fn get_clk(clocks: &CoreClocks) -> Option<Hertz>;
+}
+
+/// Timers with CK_INT derived from rcc_tim[xy]_ker_ck
+macro_rules! impl_tim_ker_ck {
+    ($($ckX:ident: $($TIMX:ident),+)+) => {
+        $(
+            $(
+                impl GetClk for $TIMX {
+                    fn get_clk(clocks: &CoreClocks) -> Option<Hertz> {
+                        Some(clocks.$ckX())
+                    }
+                }
+            )+
+        )+
+    }
+}
+impl_tim_ker_ck! {
+    timx_ker_ck: TIM2, TIM3, TIM6, TIM7
+    timy_ker_ck: TIM1
+}
+
+#[cfg(feature = "rm0481")]
+impl_tim_ker_ck! {
+    timx_ker_ck: TIM4, TIM5, TIM12
+    timy_ker_ck: TIM8, TIM15
+}
+
+/// External trait for hardware timers
+pub trait TimerExt<TIM> {
+    type Rec: ResetEnable;
+
+    /// Configures a periodic timer
+    ///
+    /// Generates an overflow event at the `timeout` frequency.
+    fn timer(self, timeout: Hertz, prec: Self::Rec, clocks: &CoreClocks)
+        -> TIM;
+
+    /// Configures the timer to count up at the given frequency
+    ///
+    /// Counts from 0 to the counter's maximum value, then repeats.
+    /// Because this only uses the timer prescaler, the frequency
+    /// is rounded to a multiple of the timer's kernel clock.
+    ///
+    /// For example, calling `.tick_timer(1.MHz(), ..)` for a 16-bit timer will
+    /// result in a timers that increments every microsecond and overflows every
+    /// ~65 milliseconds
+    fn tick_timer(
+        self,
+        frequency: Hertz,
+        prec: Self::Rec,
+        clocks: &CoreClocks,
+    ) -> TIM;
+}
+
+/// Hardware timers
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Timer<TIM> {
+    clk: u32,
+    tim: TIM,
+}
+
+/// Timer Events
+///
+/// Each event is a possible interrupt source, if enabled
+pub enum Event {
+    /// Timer timed out / count down ended
+    TimeOut,
+}
+
+macro_rules! hal {
+    ($($TIMX:ident: ($timX:ident, $Rec:ident, $cntType:ty),)+) => {
+        $(
+            impl embedded_hal_02::timer::Periodic for Timer<$TIMX> {}
+
+            impl embedded_hal_02::timer::CountDown for Timer<$TIMX> {
+                type Time = Hertz;
+
+                fn start<T>(&mut self, timeout: T)
+                where
+                    T: Into<Hertz>,
+                {
+                    // Pause
+                    self.pause();
+
+                    // Reset counter
+                    self.reset_counter();
+
+                    // UEV event occours on next overflow
+                    self.urs_counter_only();
+                    self.clear_irq();
+
+                    // Set PSC and ARR
+                    self.set_freq(timeout.into());
+
+                    // Generate an update event to force an update of the ARR register. This ensures
+                    // the first timer cycle is of the specified duration.
+                    self.apply_freq();
+
+                    // Start counter
+                    self.resume()
+                }
+
+                fn wait(&mut self) -> nb::Result<(), Void> {
+                    if self.is_irq_clear() {
+                        Err(nb::Error::WouldBlock)
+                    } else {
+                        self.clear_irq();
+                        Ok(())
+                    }
+                }
+            }
+
+            impl TimerExt<Timer<$TIMX>> for $TIMX {
+                type Rec = rec::$Rec;
+
+                fn timer(self, timeout: Hertz,
+                            prec: Self::Rec, clocks: &CoreClocks
+                ) -> Timer<$TIMX> {
+                    use embedded_hal_02::timer::CountDown;
+
+                    let mut timer = Timer::$timX(self, prec, clocks);
+                    timer.start(timeout);
+                    timer
+                }
+
+                fn tick_timer(self, frequency: Hertz,
+                                 prec: Self::Rec, clocks: &CoreClocks
+                ) -> Timer<$TIMX> {
+                    let mut timer = Timer::$timX(self, prec, clocks);
+
+                    timer.pause();
+
+                    // UEV event occours on next overflow
+                    timer.urs_counter_only();
+                    timer.clear_irq();
+
+                    // Set PSC and ARR
+                    timer.set_tick_freq(frequency);
+
+                    // Generate an update event to force an update of the ARR
+                    // register. This ensures the first timer cycle is of the
+                    // specified duration.
+                    timer.apply_freq();
+
+                    // Start counter
+                    timer.resume();
+
+                    timer
+                }
+            }
+
+            impl Timer<$TIMX> {
+                /// Configures a TIM peripheral as a periodic count down timer,
+                /// without starting it
+                pub fn $timX(tim: $TIMX, prec: rec::$Rec, clocks: &CoreClocks) -> Self
+                {
+                    // enable and reset peripheral to a clean state
+                    let _ = prec.enable().reset(); // drop, can be recreated by free method
+
+                    let clk = $TIMX::get_clk(clocks)
+                        .expect(concat!(stringify!($TIMX), ": Input clock not running!")).raw();
+
+                    Timer {
+                        clk,
+                        tim,
+                    }
+                }
+
+                /// Configures the timer's frequency and counter reload value
+                /// so that it underflows at the timeout's frequency
+                pub fn set_freq(&mut self, timeout: Hertz) {
+                    let ticks = self.clk / timeout.raw();
+
+                    self.set_timeout_ticks(ticks);
+                }
+
+                /// Sets the timer period from a time duration
+                ///
+                /// ```
+                /// use stm32h7xx_hal::time::MilliSeconds;
+                ///
+                /// // Set timeout to 100ms
+                /// let timeout = MilliSeconds::from_ticks(100).into_rate();
+                /// timer.set_timeout(timeout);
+                /// ```
+                ///
+                /// Alternatively, the duration can be set using the
+                /// core::time::Duration type
+                ///
+                /// ```
+                /// let duration = core::time::Duration::from_nanos(2_500);
+                ///
+                /// // Set timeout to 2.5µs
+                /// timer.set_timeout(duration);
+                /// ```
+                pub fn set_timeout<T>(&mut self, timeout: T)
+                where
+                    T: Into<core::time::Duration>
+                {
+                    const NANOS_PER_SECOND: u64 = 1_000_000_000;
+                    let timeout = timeout.into();
+
+                    let clk = self.clk as u64;
+                    let ticks = u32::try_from(
+                        clk * timeout.as_secs() +
+                        clk * u64::from(timeout.subsec_nanos()) / NANOS_PER_SECOND,
+                    )
+                    .unwrap_or(u32::MAX);
+
+                    self.set_timeout_ticks(ticks.max(1));
+                }
+
+                /// Sets the timer's prescaler and auto reload register so that the timer will reach
+                /// the ARR after `ticks - 1` amount of timer clock ticks.
+                ///
+                /// ```
+                /// // Set auto reload register to 50000 and prescaler to divide by 2.
+                /// timer.set_timeout_ticks(100000);
+                /// ```
+                ///
+                /// This function will round down if the prescaler is used to extend the range:
+                /// ```
+                /// // Set auto reload register to 50000 and prescaler to divide by 2.
+                /// timer.set_timeout_ticks(100001);
+                /// ```
+                fn set_timeout_ticks(&mut self, ticks: u32) {
+                    let (psc, arr) = calculate_timeout_ticks_register_values(ticks);
+                    unsafe {
+                        self.tim.psc().write(|w| w.psc().bits(psc));
+                    }
+                    #[allow(unused_unsafe)] // method is safe for some timers
+                    self.tim.arr().write(|w| unsafe { w.bits(u32(arr)) });
+                }
+
+                /// Configures the timer to count up at the given frequency
+                ///
+                /// Counts from 0 to the counter's maximum value, then repeats.
+                /// Because this only uses the timer prescaler, the frequency
+                /// is rounded to a multiple of the timer's kernel clock.
+                pub fn set_tick_freq(&mut self, frequency: Hertz) {
+                    let div = self.clk / frequency.raw();
+
+                    let psc = u16(div - 1).unwrap();
+                    unsafe {
+                        self.tim.psc().write(|w| w.psc().bits(psc));
+                    }
+
+                    let counter_max = u32(<$cntType>::MAX);
+                    #[allow(unused_unsafe)] // method is safe for some timers
+                    self.tim.arr().write(|w| unsafe { w.bits(counter_max) });
+                }
+
+                /// Applies frequency/timeout changes immediately
+                ///
+                /// The timer will normally update its prescaler and auto-reload
+                /// value when its counter overflows. This function causes
+                /// those changes to happen immediately. Also clears the counter.
+                pub fn apply_freq(&mut self) {
+                    self.tim.egr().write(|w| w.ug().set_bit());
+                }
+
+                /// Pauses the TIM peripheral
+                pub fn pause(&mut self) {
+                    self.tim.cr1().modify(|_, w| w.cen().clear_bit());
+                }
+
+                /// Resume (unpause) the TIM peripheral
+                pub fn resume(&mut self) {
+                    self.tim.cr1().modify(|_, w| w.cen().set_bit());
+                }
+
+                /// Set Update Request Source to counter overflow/underflow only
+                pub fn urs_counter_only(&mut self) {
+                    self.tim.cr1().modify(|_, w| w.urs().counter_only());
+                }
+
+                /// Reset the counter of the TIM peripheral
+                pub fn reset_counter(&mut self) {
+                    self.tim.cnt().reset();
+                }
+
+                /// Read the counter of the TIM peripheral
+                pub fn counter(&self) -> u32 {
+                    self.tim.cnt().read().cnt().bits().into()
+                }
+
+                /// Start listening for `event`
+                pub fn listen(&mut self, event: Event) {
+                    match event {
+                        Event::TimeOut => {
+                            // Enable update event interrupt
+                            self.tim.dier().write(|w| w.uie().set_bit());
+                        }
+                    }
+                }
+
+                /// Stop listening for `event`
+                pub fn unlisten(&mut self, event: Event) {
+                    match event {
+                        Event::TimeOut => {
+                            // Disable update event interrupt
+                            self.tim.dier().write(|w| w.uie().clear_bit());
+                            let _ = self.tim.dier().read();
+                            let _ = self.tim.dier().read(); // Delay 2 peripheral clocks
+                        }
+                    }
+                }
+
+                /// Check if Update Interrupt flag is cleared
+                pub fn is_irq_clear(&mut self) -> bool {
+                    self.tim.sr().read().uif().bit_is_clear()
+                }
+
+                /// Clears interrupt flag
+                pub fn clear_irq(&mut self) {
+                    self.tim.sr().modify(|_, w| {
+                        // Clears timeout event
+                        w.uif().clear_bit()
+                    });
+                    let _ = self.tim.sr().read();
+                    let _ = self.tim.sr().read(); // Delay 2 peripheral clocks
+                }
+
+                /// Releases the TIM peripheral
+                pub fn free(mut self) -> ($TIMX, rec::$Rec) {
+                    // pause counter
+                    self.pause();
+
+                    (self.tim, rec::$Rec { _marker: PhantomData })
+                }
+
+                /// Returns a reference to the inner peripheral
+                pub fn inner(&self) -> &$TIMX {
+                    &self.tim
+                }
+
+                /// Returns a mutable reference to the inner peripheral
+                pub fn inner_mut(&mut self) -> &mut $TIMX {
+                    &mut self.tim
+                }
+            }
+        )+
+    }
+}
+
+/// We want to have `ticks` amount of timer ticks before it reloads.
+/// But `ticks` may have a higher value than what the timer can hold directly.
+/// So we'll use the prescaler to extend the range.
+///
+/// To know how many times we would overflow with a prescaler of 1, we divide `ticks` by 2^16 (the max amount of ticks per overflow).
+/// If the result is e.g. 3, then we need to increase our range by 4 times to fit all the ticks.
+/// We can increase the range enough by setting the prescaler to 3 (which will divide the clock freq by 4).
+/// Because every tick is now 4x as long, we need to divide `ticks` by 4 to keep the same timeout.
+///
+/// This function returns the prescaler register value and auto reload register value.
+fn calculate_timeout_ticks_register_values(ticks: u32) -> (u16, u16) {
+    // Note (unwrap): Never panics because 32-bit value is shifted right by 16 bits,
+    // resulting in a value that always fits in 16 bits.
+    let psc = u16(ticks / (1 << 16)).unwrap();
+    // Note (unwrap): Never panics because the divisor is always such that the result fits in 16 bits.
+    // Also note that the timer counts `0..=arr`, so subtract 1 to get the correct period.
+    let arr = u16(ticks / (u32(psc) + 1)).unwrap().saturating_sub(1);
+    (psc, arr)
+}
+
+hal! {
+    // Advanced-control
+    TIM1: (tim1, Tim1, u16),
+
+    // General-purpose
+    TIM2: (tim2, Tim2, u32),
+    TIM3: (tim3, Tim3, u16),
+
+    // Basic
+    TIM6: (tim6, Tim6, u16),
+    TIM7: (tim7, Tim7, u16),
+}
+
+#[cfg(feature = "rm0481")]
+hal! {
+    // Advanced-control
+    TIM8: (tim8, Tim8, u16),
+
+    // General-purpose
+    TIM4: (tim4, Tim4, u16),
+    TIM5: (tim5, Tim5, u32),
+
+    // General-purpose
+    TIM12: (tim12, Tim12, u16),
+
+    // General-purpose
+    TIM15: (tim15, Tim15, u16),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timeout_ticks_register_values() {
+        assert_eq!(calculate_timeout_ticks_register_values(0), (0, 0));
+        assert_eq!(calculate_timeout_ticks_register_values(50000), (0, 49999));
+        assert_eq!(calculate_timeout_ticks_register_values(100000), (1, 49999));
+        assert_eq!(calculate_timeout_ticks_register_values(65535), (0, 65534));
+        assert_eq!(calculate_timeout_ticks_register_values(65536), (1, 32767));
+        assert_eq!(
+            calculate_timeout_ticks_register_values(1000000),
+            (15, 62499)
+        );
+        assert_eq!(
+            calculate_timeout_ticks_register_values(u32::MAX),
+            (u16::MAX, u16::MAX - 1)
+        );
+    }
+}

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -12,7 +12,7 @@ use core::marker::PhantomData;
 
 use crate::stm32::{TIM1, TIM2, TIM3, TIM6, TIM7};
 #[cfg(feature = "rm0481")]
-use crate::stm32::{TIM12, TIM15, TIM4, TIM5, TIM8};
+use crate::stm32::{/*TIM12, */TIM15, TIM4, TIM5, TIM8}; // TODO: TIM12 seems to be missing for 523's pac, re add once fixed
 
 use cast::{u16, u32};
 use void::Void;
@@ -46,7 +46,7 @@ impl_tim_ker_ck! {
 
 #[cfg(feature = "rm0481")]
 impl_tim_ker_ck! {
-    timx_ker_ck: TIM4, TIM5, TIM12
+    timx_ker_ck: TIM4, TIM5 //TIM12 // TODO: TIM12 seems to be missing for 523's pac, re add once fixed
     timy_ker_ck: TIM8, TIM15
 }
 
@@ -412,7 +412,7 @@ hal! {
     TIM5: (tim5, Tim5, u32),
 
     // General-purpose
-    TIM12: (tim12, Tim12, u16),
+    //TIM12: (tim12, Tim12, u16), // TODO: TIM12 seems to be missing for 523's pac, re add once fixed
 
     // General-purpose
     TIM15: (tim15, Tim15, u16),

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,21 +1,77 @@
 //! Timers
 //!
+//! The STM32H5 family includes a rich set of timers, with different sets of functionality. The
+//! Basic timer simply allows for timer operation based on a counter overflow. The General-Purpose
+//! timers also include Input Compare, Output Compare, and PWM operation. The Advanced Timers
+//! include more advanced PWM functionality. See the RM0492/RM0481 Reference Manual for detailed
+//! information of what timer provides what functionality.
+//!
+//! # Counter width
+//! Different timers support different auto-reload counter widths which allow for longer time
+//! periods between update events.
+//!
+//! # Basic Timer
+//! The basic timer operation is exposed either as a periodic timer that generates a timeout at
+//! a specific frequency or as a as a timer that counts ticks up to the maximum overflow value at
+//! a specific frequency. In both cases, the timer can generate an interrupt on timer overflow.
+//!
+//! ## [`Timeout``] timer
+//! The timeout timer runs continuously once started, and generates an overflow event at the
+//! frequency specified. This can be used to trigger single or repeated events after specific
+//! time periods.
+//!
+//! ### Starting with a overflow frequency
+//! ```
+//! let dp = ...;            // Device peripherals
+//!
+//! let timeout = dp.TIM1.timeout(ccdr.peripheral.TIM1, &ccdr.clocks);
+//! timeout.start_with_frequency(2.Hz());
+//! ```
+//!
+//! ### Starting with an overflow timeout
+//! ```
+//! let dp = ...;            // Device peripherals
+//!
+//! let timeout = dp.TIM1.timeout(ccdr.peripheral.TIM1, &ccdr.clocks);
+//! timeout.start_with_timeout(500.millis());
+//! timeout.wait_for_overflow();
+//! ```
+//!
+//! ## Tick timer
+//! The tick timer runs continuously, incrementing the timer counter register at the frequency
+//! specified. This can be used to generate for timing purposes (e.g. a monotonic clock).
+//!
+//! ### Usage
+//! ```
+//! let dp = ...;            // Device peripherals
+//!
+//! let tick = dp.TIM1.tick(ccdr.peripheral.TIM1, &ccdr.clocks);
+//! tick.start(1.MHz());
+//! ```
 //! # Examples
 //!
 //! - [Blinky using a Timer](https://github.com/stm32-rs/stm32h5xx-hal/blob/master/examples/blinky_timer.rs)
 
+use core::fmt::Debug;
 use core::marker::PhantomData;
 
 use crate::stm32::{TIM1, TIM2, TIM3, TIM6, TIM7};
 #[cfg(feature = "rm0481")]
-use crate::stm32::{/*TIM12,*/ TIM15, TIM4, TIM5, TIM8}; // TODO: TIM12 seems to be missing for 523's pac, re add once fixed
+use crate::stm32::{TIM12, TIM15, TIM4, TIM5, TIM8};
 #[cfg(feature = "h56x_h573")]
 use crate::stm32::{TIM13, TIM14, TIM16, TIM17};
 
 use crate::rcc::{rec, CoreClocks, ResetEnable};
 use crate::time::Hertz;
 
-trait Counter: Into<u32> + TryFrom<u32> + From<u16> {
+mod counters;
+
+pub use counters::{Tick, Timeout};
+
+/// Counter represents the word type used for setting the period of timer.
+/// Consult RM0492/RM0481 for which timer supports which word sizes.
+#[doc(hidden)]
+pub trait Counter: Into<u32> + TryFrom<u32> + From<u16> + Debug {
     const MAX: Self;
 }
 
@@ -27,6 +83,7 @@ impl Counter for u32 {
     const MAX: u32 = u32::MAX;
 }
 
+#[doc(hidden)]
 pub trait Instance: crate::Sealed + Sized {
     type Rec: ResetEnable;
 
@@ -37,79 +94,83 @@ pub trait Instance: crate::Sealed + Sized {
 }
 
 macro_rules! timer {
-    ($TIMX:ident: $cntType:ty, $ker_ck:ident) => { paste::item! {
-        impl crate::Sealed for $TIMX {}
+    ($TIMX:ident: $cntType:ty, $ker_ck:ident) => {
+        paste::item! {
+            impl crate::Sealed for $TIMX {}
 
-        impl Instance for $TIMX {
-            type Rec = rec::[< $TIMX:lower:camel >];
+            impl Instance for $TIMX {
+                type Rec = rec::[< $TIMX:lower:camel >];
 
-            fn clock(clocks: &CoreClocks) -> Hertz {
-                clocks.$ker_ck()
+                fn clock(clocks: &CoreClocks) -> Hertz {
+                    clocks.$ker_ck()
+                }
+
+                fn rec() -> Self::Rec {
+                    rec::[< $TIMX:lower:camel >] { _marker: PhantomData }
+                }
             }
 
-            fn rec() -> Self::Rec {
-                rec::[< $TIMX:lower:camel >] { _marker: PhantomData }
+            impl Basic for $TIMX {
+                type Counter = $cntType;
+                fn set_prescalar(&mut self, psc: u16) {
+                    self.psc().write(|w| w.psc().set(psc));
+                }
+
+                fn set_auto_reload(&mut self, arr: Self::Counter) {
+                    self.arr().write(|w| w.arr().set(arr.into()));
+                }
+
+                fn apply_freq(&mut self) {
+                    self.egr().write(|w| w.ug().update());
+                }
+
+                fn pause(&mut self) {
+                    self.cr1().modify(|_, w| w.cen().disabled());
+                }
+
+                fn resume(&mut self) {
+                    self.cr1().modify(|_, w| w.cen().enabled());
+                }
+
+                fn urs_counter_only(&mut self) {
+                    self.cr1().modify(|_, w| w.urs().counter_only());
+                }
+
+                /// Reset the counter of the TIM peripheral
+                fn reset_counter(&mut self) {
+                    self.cnt().reset();
+                }
+
+                fn counter(&self) -> Self::Counter {
+                    self.cnt().read().cnt().bits()
+                }
+
+                fn enable_timeout_interrupt(&mut self) {
+                    // Enable update event interrupt
+                    self.dier().write(|w| w.uie().enabled());
+                }
+
+                fn disable_timeout_interrupt(&mut self) {
+                    self.dier().write(|w| w.uie().disabled());
+                    interrupt_clear_clock_sync_delay!(self.dier());
+                }
+
+
+                fn is_timeout_complete(&self) -> bool {
+                    self.sr().read().uif().is_update_pending()
+                }
+
+                /// Clears interrupt flag
+                fn clear_timeout_flag(&mut self) {
+                    self.sr().modify(|_, w| {
+                        // Clears timeout event
+                        w.uif().clear()
+                    });
+                    interrupt_clear_clock_sync_delay!(self.sr());
+                }
             }
         }
-
-        impl Basic for $TIMX {
-            type Counter = $cntType;
-            fn set_prescalar(&mut self, psc: u16) {
-                self.psc().write(|w| w.psc().set(psc));
-
-            }
-
-            fn set_arr(&mut self, arr: Self::Counter) {
-                // #[allow(unused_unsafe)] // method is safe for some timers
-                self.arr().write(|w| w.arr().set(arr.into()));
-            }
-
-            fn apply_freq(&mut self) {
-                self.egr().write(|w| w.ug().update());
-            }
-
-            fn pause(&mut self) {
-                self.cr1().modify(|_, w| w.cen().disabled());
-            }
-
-            fn resume(&mut self) {
-                self.cr1().modify(|_, w| w.cen().enabled());
-            }
-
-            fn urs_counter_only(&mut self) {
-                self.cr1().modify(|_, w| w.urs().counter_only());
-            }
-
-            /// Reset the counter of the TIM peripheral
-            fn reset_counter(&mut self) {
-                self.cnt().reset();
-            }
-
-            fn enable_timeout_interrupt(&mut self) {
-                // Enable update event interrupt
-                self.dier().write(|w| w.uie().enabled());
-            }
-
-            fn disable_timeout_interrupt(&mut self) {
-                self.dier().write(|w| w.uie().disabled());
-                interrupt_clear_clock_sync_delay!(self.dier());
-            }
-
-
-            fn is_timeout_complete(&mut self) -> bool {
-                self.sr().read().uif().is_update_pending()
-            }
-
-            /// Clears interrupt flag
-            fn clear_timeout_flag(&mut self) {
-                self.sr().modify(|_, w| {
-                    // Clears timeout event
-                    w.uif().clear()
-                });
-                interrupt_clear_clock_sync_delay!(self.sr());
-            }
-        }
-    }};
+    };
 }
 
 // Advanced Control
@@ -133,7 +194,7 @@ mod rm0481 {
     timer!(TIM4: u16, timx_ker_ck);
     timer!(TIM5: u32, timx_ker_ck);
     timer!(TIM15: u16, timy_ker_ck);
-    //timer!(TIM12, u16, timx_ker_ck), // TODO: TIM12 seems to be missing for 523's pac, re add once fixed
+    timer!(TIM12: u16, timx_ker_ck);
 }
 
 #[cfg(feature = "h56x_h573")]
@@ -150,9 +211,11 @@ mod h56x_h573 {
 pub trait TimerExt<TIM: Instance> {
     /// Configures a periodic timer
     ///
-    /// Generates an overflow event at the `timeout` frequency.
-    fn timer(self, timeout: Hertz, prec: TIM::Rec, clocks: &CoreClocks)
-        -> Timer<TIM>;
+    /// Generates an overflow event at the timeout frequency. The timer
+    /// can be started using either of [`Timeout::start_with_frequency`] or
+    /// [`Timeout::start_with_timeout`] to schedule timeouts either at the
+    /// frequency specified or after period specified, respectively.
+    fn timeout(self, prec: TIM::Rec, clocks: &CoreClocks) -> Timeout<TIM>;
 
     /// Configures the timer to count up at the given frequency
     ///
@@ -160,15 +223,10 @@ pub trait TimerExt<TIM: Instance> {
     /// Because this only uses the timer prescaler, the frequency
     /// is rounded to a multiple of the timer's kernel clock.
     ///
-    /// For example, calling `.tick_timer(1.MHz(), ..)` for a 16-bit timer will
-    /// result in a timers that increments every microsecond and overflows every
+    /// For example, calling `.start(1.MHz())` for a 16-bit timer will
+    /// result in a timer that increments every microsecond and overflows every
     /// ~65 milliseconds
-    fn tick_timer(
-        self,
-        frequency: Hertz,
-        prec: TIM::Rec,
-        clocks: &CoreClocks,
-    ) -> Timer<TIM>;
+    fn tick(self, prec: TIM::Rec, clocks: &CoreClocks) -> Tick<TIM>;
 }
 
 /// Hardware timers
@@ -180,40 +238,23 @@ pub struct Timer<TIM> {
 }
 
 impl<TIM: Instance + Basic> TimerExt<TIM> for TIM {
-    fn timer(self, timeout: Hertz,
-                prec: TIM::Rec, clocks: &CoreClocks
-    ) -> Timer<TIM> {
-        let mut timer = Timer::new(self, prec, clocks);
-        timer.start(timeout);
-        timer
+    fn timeout(self, prec: TIM::Rec, clocks: &CoreClocks) -> Timeout<TIM> {
+        Timer::new(self, prec, clocks).timeout()
     }
 
-    fn tick_timer(self, frequency: Hertz,
-                     prec: TIM::Rec, clocks: &CoreClocks
-    ) -> Timer<TIM> {
-        let mut timer = Timer::new(self, prec, clocks);
-
-        timer.tick_timer(frequency);
-
-        timer
+    fn tick(self, prec: TIM::Rec, clocks: &CoreClocks) -> Tick<TIM> {
+        Timer::new(self, prec, clocks).tick()
     }
 }
 
 impl<TIM: Instance> Timer<TIM> {
-    /// Configures a TIM peripheral as a periodic count down timer,
-    /// without starting it
-    pub fn new(tim: TIM, prec: TIM::Rec, clocks: &CoreClocks) -> Self
-    {
-        // enable and reset peripheral to a clean state
-        let _ = prec.enable().reset(); // drop, can be recreated by free method
+    pub fn new(tim: TIM, prec: TIM::Rec, clocks: &CoreClocks) -> Self {
+        // Enable and reset peripheral to a clean state
+        let _ = prec.enable().reset();
 
         let clk = TIM::clock(clocks).raw();
-            // .expect(concat!(stringify!(TIM), ": Input clock not running!")).raw();
 
-        Timer {
-            clk,
-            tim,
-        }
+        Timer { clk, tim }
     }
 
     /// Returns a reference to the inner peripheral
@@ -227,79 +268,17 @@ impl<TIM: Instance> Timer<TIM> {
     }
 }
 
-#[allow(private_bounds)]
 impl<TIM: Instance + Basic> Timer<TIM> {
-    /// Configures the timer's frequency and counter reload value
-    /// so that it underflows at the timeout's frequency
-    pub fn set_freq(&mut self, timeout: Hertz) {
-        let ticks = self.clk / timeout.raw();
-
-        self.set_timeout_ticks(ticks);
+    fn timeout(self) -> Timeout<TIM> {
+        Timeout::new(self)
     }
 
-    /// Sets the timer period from a time duration
-    ///
-    /// ```
-    /// use stm32h5xx_hal::time::MilliSeconds;
-    ///
-    /// // Set timeout to 100ms
-    /// let timeout = MilliSeconds::from_ticks(100).into_rate();
-    /// timer.set_timeout(timeout);
-    /// ```
-    ///
-    /// Alternatively, the duration can be set using the
-    /// core::time::Duration type
-    ///
-    /// ```
-    /// let duration = core::time::Duration::from_nanos(2_500);
-    ///
-    /// // Set timeout to 2.5µs
-    /// timer.set_timeout(duration);
-    /// ```
-    pub fn set_timeout<T>(&mut self, timeout: T)
-    where
-        T: Into<core::time::Duration>
-    {
-        const NANOS_PER_SECOND: u64 = 1_000_000_000;
-        let timeout = timeout.into();
-
-        let clk = self.clk as u64;
-        let ticks = u32::try_from(
-            clk * timeout.as_secs() +
-            clk * u64::from(timeout.subsec_nanos()) / NANOS_PER_SECOND,
-        )
-        .unwrap_or(u32::MAX);
-
-        self.set_timeout_ticks(ticks.max(1));
-    }
-
-    pub fn start<T>(&mut self, timeout: T)
-                where
-                    T: Into<Hertz>,
-    {
-        // Pause
-        self.tim.pause();
-
-        // Reset counter
-        self.tim.reset_counter();
-
-        // UEV event occours on next overflow
-        self.tim.urs_counter_only();
-        self.tim.clear_timeout_flag();
-
-        // Set PSC and ARR
-        self.set_freq(timeout.into());
-
-        // Generate an update event to force an update of the ARR register. This ensures
-        // the first timer cycle is of the specified duration.
-        self.tim.apply_freq();
-
-        // Start counter
-        self.tim.resume()
+    fn tick(self) -> Tick<TIM> {
+        Tick::new(self)
     }
 
     /// Check whether the timeout has occurred and clear status flags if it has
-    pub fn check_clear_timeout(&mut self) -> bool {
+    pub fn check_clear_overflow(&mut self) -> bool {
         if self.tim.is_timeout_complete() {
             self.tim.clear_timeout_flag();
             true
@@ -309,27 +288,13 @@ impl<TIM: Instance + Basic> Timer<TIM> {
     }
 
     /// Blocks until timeout occurs
-    pub fn wait_for_timeout(&mut self) {
-        while !self.check_clear_timeout() {}
+    pub fn wait_for_overflow(&mut self) {
+        while !self.check_clear_overflow() {}
     }
 
-    fn tick_timer(&mut self, frequency: Hertz) {
-        self.tim.pause();
-
-        // UEV event occours on next overflow
-        self.tim.urs_counter_only();
-        self.tim.clear_timeout_flag();
-
-        // Set PSC and ARR
-        self.set_tick_freq(frequency);
-
-        // Generate an update event to force an update of the ARR
-        // register. This ensures the first timer cycle is of the
-        // specified duration.
-        self.tim.apply_freq();
-
-        // Start counter
-        self.tim.resume();
+    /// Read the value of the timer counter
+    pub fn counter_value(&self) -> u32 {
+        self.tim.counter().into()
     }
 
     /// Sets the timer's prescaler and auto reload register so that the timer will reach
@@ -348,23 +313,7 @@ impl<TIM: Instance + Basic> Timer<TIM> {
     fn set_timeout_ticks(&mut self, ticks: u32) {
         let (psc, arr) = calculate_timeout_ticks_register_values(ticks);
         self.tim.set_prescalar(psc.into());
-        self.tim.set_arr(arr.into());
-    }
-
-    /// Configures the timer to count up at the given frequency
-    ///
-    /// Counts from 0 to the counter's maximum value, then repeats.
-    /// Because this only uses the timer prescaler, the frequency
-    /// is rounded to a multiple of the timer's kernel clock.
-    pub fn set_tick_freq(&mut self, frequency: Hertz) {
-        let div = self.clk / frequency.raw();
-
-        // TODO: This only works for frequencies high enough to result in a 16-bit divisor. Consider removing
-        let psc = u16::try_from(div - 1).unwrap();
-        self.tim.set_prescalar(psc);
-
-        let counter_max = TIM::Counter::MAX;
-        self.tim.set_arr(counter_max);
+        self.tim.set_auto_reload(arr.into());
     }
 
     /// Enable timeout interrupt. This maps to the Update Event timeout
@@ -377,11 +326,15 @@ impl<TIM: Instance + Basic> Timer<TIM> {
         self.tim.disable_timeout_interrupt();
     }
 
-    /// Releases the TIM peripheral
-    pub fn free(mut self) -> (TIM, TIM::Rec) {
-        // pause counter
+    /// Cancel timer
+    pub fn cancel(&mut self) {
         self.tim.pause();
         self.tim.disable_timeout_interrupt();
+    }
+
+    /// Releases the TIM peripheral
+    fn free(mut self) -> (TIM, TIM::Rec) {
+        self.cancel();
 
         (self.tim, TIM::rec())
     }
@@ -390,11 +343,12 @@ impl<TIM: Instance + Basic> Timer<TIM> {
 /// The Basic trait represents functionality common to all timers (Basic, General Purpose, and
 /// Advanced-control Timers), as described in RM0492 and RM0481. It facilitates basic timeout
 /// operations which are exposed on the [`Timer`] instance for all TIM peripherals.
-trait Basic {
+#[doc(hidden)]
+pub trait Basic {
     type Counter: Counter;
     fn set_prescalar(&mut self, psc: u16);
 
-    fn set_arr(&mut self, arr: Self::Counter);
+    fn set_auto_reload(&mut self, arr: Self::Counter);
 
     /// Applies frequency/timeout changes immediately
     ///
@@ -415,13 +369,17 @@ trait Basic {
     /// Reset the counter of the TIM peripheral
     fn reset_counter(&mut self);
 
-    /// Enable timeout interrupt for
+    /// Timer counter value
+    fn counter(&self) -> Self::Counter;
+
+    /// Enable timeout interrupt
     fn enable_timeout_interrupt(&mut self);
 
+    /// Disable timeout interrupt
     fn disable_timeout_interrupt(&mut self);
 
     /// Check if Update Interrupt flag is cleared
-    fn is_timeout_complete(&mut self) -> bool;
+    fn is_timeout_complete(&self) -> bool;
 
     /// Clears interrupt flag
     fn clear_timeout_flag(&mut self);
@@ -444,7 +402,9 @@ fn calculate_timeout_ticks_register_values(ticks: u32) -> (u16, u16) {
     let psc = (ticks / (1 << u16::BITS)).try_into().unwrap();
     // Note (unwrap): Never panics because the divisor is always such that the result fits in 16 bits.
     // Also note that the timer counts `0..=arr`, so subtract 1 to get the correct period.
-    let arr = u16::try_from(ticks / ((psc as u32) + 1)).unwrap().saturating_sub(1);
+    let arr = u16::try_from(ticks / ((psc as u32) + 1))
+        .unwrap()
+        .saturating_sub(1);
     (psc, arr)
 }
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -65,7 +65,7 @@ pub use counters::{Tick, Timeout};
 /// Counter represents the word type used for setting the period of timer.
 /// Consult RM0492/RM0481 for which timer supports which word sizes.
 #[doc(hidden)]
-pub trait Counter: Into<u32> + TryFrom<u32> + From<u16> + Debug {
+pub trait Counter: crate::Sealed + Into<u32> + TryFrom<u32> + From<u16> + Debug {
     const MAX: Self;
 }
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -194,7 +194,7 @@ impl<TIM: Instance + Basic> Timer<TIM> {
     /// ```
     fn set_timeout_ticks(&mut self, ticks: u32) {
         let (psc, arr) = calculate_timeout_ticks_register_values(ticks);
-        self.tim.set_prescalar(psc.into());
+        self.tim.set_prescalar(psc);
         self.tim.set_auto_reload(arr.into());
     }
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -53,18 +53,12 @@
 //! - [Blinky using a Timer](https://github.com/stm32-rs/stm32h5xx-hal/blob/master/examples/blinky_timer.rs)
 
 use core::fmt::Debug;
-use core::marker::PhantomData;
 
-use crate::stm32::{TIM1, TIM2, TIM3, TIM6, TIM7};
-#[cfg(feature = "rm0481")]
-use crate::stm32::{TIM12, TIM15, TIM4, TIM5, TIM8};
-#[cfg(feature = "h56x_h573")]
-use crate::stm32::{TIM13, TIM14, TIM16, TIM17};
-
-use crate::rcc::{rec, CoreClocks, ResetEnable};
+use crate::rcc::{CoreClocks, ResetEnable};
 use crate::time::Hertz;
 
 mod counters;
+mod timer_def;
 
 pub use counters::{Tick, Timeout};
 
@@ -91,120 +85,6 @@ pub trait Instance: crate::Sealed + Sized {
     fn clock(clocks: &CoreClocks) -> Hertz;
 
     fn rec() -> Self::Rec;
-}
-
-macro_rules! timer {
-    ($TIMX:ident: $cntType:ty, $ker_ck:ident) => {
-        paste::item! {
-            impl crate::Sealed for $TIMX {}
-
-            impl Instance for $TIMX {
-                type Rec = rec::[< $TIMX:lower:camel >];
-
-                fn clock(clocks: &CoreClocks) -> Hertz {
-                    clocks.$ker_ck()
-                }
-
-                fn rec() -> Self::Rec {
-                    rec::[< $TIMX:lower:camel >] { _marker: PhantomData }
-                }
-            }
-
-            impl Basic for $TIMX {
-                type Counter = $cntType;
-                fn set_prescalar(&mut self, psc: u16) {
-                    self.psc().write(|w| w.psc().set(psc));
-                }
-
-                fn set_auto_reload(&mut self, arr: Self::Counter) {
-                    self.arr().write(|w| w.arr().set(arr.into()));
-                }
-
-                fn apply_freq(&mut self) {
-                    self.egr().write(|w| w.ug().update());
-                }
-
-                fn pause(&mut self) {
-                    self.cr1().modify(|_, w| w.cen().disabled());
-                }
-
-                fn resume(&mut self) {
-                    self.cr1().modify(|_, w| w.cen().enabled());
-                }
-
-                fn urs_counter_only(&mut self) {
-                    self.cr1().modify(|_, w| w.urs().counter_only());
-                }
-
-                /// Reset the counter of the TIM peripheral
-                fn reset_counter(&mut self) {
-                    self.cnt().reset();
-                }
-
-                fn counter(&self) -> Self::Counter {
-                    self.cnt().read().cnt().bits()
-                }
-
-                fn enable_timeout_interrupt(&mut self) {
-                    // Enable update event interrupt
-                    self.dier().write(|w| w.uie().enabled());
-                }
-
-                fn disable_timeout_interrupt(&mut self) {
-                    self.dier().write(|w| w.uie().disabled());
-                    interrupt_clear_clock_sync_delay!(self.dier());
-                }
-
-
-                fn is_timeout_complete(&self) -> bool {
-                    self.sr().read().uif().is_update_pending()
-                }
-
-                /// Clears interrupt flag
-                fn clear_timeout_flag(&mut self) {
-                    self.sr().modify(|_, w| {
-                        // Clears timeout event
-                        w.uif().clear()
-                    });
-                    interrupt_clear_clock_sync_delay!(self.sr());
-                }
-            }
-        }
-    };
-}
-
-// Advanced Control
-timer!(TIM1: u16, timy_ker_ck);
-
-// General-purpose
-timer!(TIM2: u32, timx_ker_ck);
-timer!(TIM3: u16, timx_ker_ck);
-
-// Basic
-timer!(TIM6: u16, timx_ker_ck);
-timer!(TIM7: u16, timx_ker_ck);
-
-#[cfg(feature = "rm0481")]
-mod rm0481 {
-    use super::*;
-    // Advanced-control
-    timer!(TIM8: u16, timy_ker_ck);
-
-    // General-purpose
-    timer!(TIM4: u16, timx_ker_ck);
-    timer!(TIM5: u32, timx_ker_ck);
-    timer!(TIM15: u16, timy_ker_ck);
-    timer!(TIM12: u16, timx_ker_ck);
-}
-
-#[cfg(feature = "h56x_h573")]
-mod h56x_h573 {
-    use super::*;
-    // General-purpose
-    timer!(TIM13: u16, timx_ker_ck);
-    timer!(TIM14: u16, timx_ker_ck);
-    timer!(TIM16: u16, timy_ker_ck);
-    timer!(TIM17: u16, timy_ker_ck);
 }
 
 /// External trait for hardware timers

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -2,63 +2,156 @@
 //!
 //! # Examples
 //!
-//! - [Blinky using a Timer](https://github.com/stm32-rs/stm32h7xx-hal/blob/master/examples/blinky_timer.rs)
-//! - [64 bit microsecond timer](https://github.com/stm32-rs/stm32h7xx-hal/blob/master/examples/tick_timer.rs)
-
-// TODO: on the h7x3 at least, only TIM2, TIM3, TIM4, TIM5 can support 32 bits.
-// TIM1 is 16 bit.
+//! - [Blinky using a Timer](https://github.com/stm32-rs/stm32h5xx-hal/blob/master/examples/blinky_timer.rs)
 
 use core::marker::PhantomData;
 
 use crate::stm32::{TIM1, TIM2, TIM3, TIM6, TIM7};
 #[cfg(feature = "rm0481")]
-use crate::stm32::{/*TIM12, */TIM15, TIM4, TIM5, TIM8}; // TODO: TIM12 seems to be missing for 523's pac, re add once fixed
-
-use cast::{u16, u32};
-use void::Void;
+use crate::stm32::{/*TIM12,*/ TIM15, TIM4, TIM5, TIM8}; // TODO: TIM12 seems to be missing for 523's pac, re add once fixed
 
 use crate::rcc::{rec, CoreClocks, ResetEnable};
 use crate::time::Hertz;
 
-/// Associate clocks with timers
-pub trait GetClk {
-    fn get_clk(clocks: &CoreClocks) -> Option<Hertz>;
+trait Counter: Into<u32> + TryFrom<u32> + From<u16> {
+    const MAX: Self;
 }
 
-/// Timers with CK_INT derived from rcc_tim[xy]_ker_ck
-macro_rules! impl_tim_ker_ck {
-    ($($ckX:ident: $($TIMX:ident),+)+) => {
-        $(
-            $(
-                impl GetClk for $TIMX {
-                    fn get_clk(clocks: &CoreClocks) -> Option<Hertz> {
-                        Some(clocks.$ckX())
-                    }
+impl Counter for u16 {
+    const MAX: u16 = u16::MAX;
+}
+
+impl Counter for u32 {
+    const MAX: u32 = u32::MAX;
+}
+
+pub trait Instance: crate::Sealed + Sized {
+    type Rec: ResetEnable;
+
+    #[doc(hidden)]
+    fn clock(clocks: &CoreClocks) -> Hertz;
+
+    fn rec() -> Self::Rec;
+}
+
+macro_rules! timer {
+    ($TIMX:ident: $cntType:ty, $ker_ck:ident) => { paste::item! {
+        impl crate::Sealed for $TIMX {}
+
+        impl Instance for $TIMX {
+            type Rec = rec::[< $TIMX:lower:camel >];
+
+            fn clock(clocks: &CoreClocks) -> Hertz {
+                clocks.$ker_ck()
+            }
+
+            fn rec() -> Self::Rec {
+                rec::[< $TIMX:lower:camel >] { _marker: PhantomData }
+            }
+        }
+
+        impl Basic for $TIMX {
+            type Counter = $cntType;
+            fn set_prescalar(&mut self, psc: u16) {
+                unsafe {
+                    self.psc().write(|w| w.psc().bits(psc));
                 }
-            )+
-        )+
-    }
+            }
+
+            fn set_arr(&mut self, arr: Self::Counter) {
+                // #[allow(unused_unsafe)] // method is safe for some timers
+                self.arr().write(|w| w.arr().set(arr.into()));
+            }
+
+            fn apply_freq(&mut self) {
+                self.egr().write(|w| w.ug().update());
+            }
+
+            fn pause(&mut self) {
+                self.cr1().modify(|_, w| w.cen().disabled());
+            }
+
+            fn resume(&mut self) {
+                self.cr1().modify(|_, w| w.cen().enabled());
+            }
+
+            fn urs_counter_only(&mut self) {
+                self.cr1().modify(|_, w| w.urs().counter_only());
+            }
+
+            /// Reset the counter of the TIM peripheral
+            fn reset_counter(&mut self) {
+                self.cnt().reset();
+            }
+
+            fn enable_timeout_interrupt(&mut self) {
+                // Enable update event interrupt
+                self.dier().write(|w| w.uie().enabled());
+            }
+
+            fn disable_timeout_interrupt(&mut self) {
+                self.dier().write(|w| w.uie().disabled());
+                interrupt_clear_clock_sync_delay!(self.dier());
+            }
+
+
+            fn is_timeout_complete(&mut self) -> bool {
+                self.sr().read().uif().is_update_pending()
+            }
+
+            /// Clears interrupt flag
+            fn clear_timeout_flag(&mut self) {
+                self.sr().modify(|_, w| {
+                    // Clears timeout event
+                    w.uif().clear()
+                });
+                interrupt_clear_clock_sync_delay!(self.sr());
+            }
+        }
+    }};
 }
-impl_tim_ker_ck! {
-    timx_ker_ck: TIM2, TIM3, TIM6, TIM7
-    timy_ker_ck: TIM1
-}
+
+// Advanced Control
+timer!(TIM1: u16, timy_ker_ck);
+
+// General-purpose
+timer!(TIM2: u32, timx_ker_ck);
+timer!(TIM3: u16, timx_ker_ck);
+
+// Basic
+timer!(TIM6: u16, timx_ker_ck);
+timer!(TIM7: u16, timx_ker_ck);
 
 #[cfg(feature = "rm0481")]
-impl_tim_ker_ck! {
-    timx_ker_ck: TIM4, TIM5 //TIM12 // TODO: TIM12 seems to be missing for 523's pac, re add once fixed
-    timy_ker_ck: TIM8, TIM15
+mod rm0481 {
+    use super::*;
+    // Advanced-control
+    timer!(TIM8: u16, timy_ker_ck);
+
+    // General-purpose
+    timer!(TIM4: u16, timx_ker_ck);
+    timer!(TIM5: u32, timx_ker_ck);
+    timer!(TIM15: u16, timy_ker_ck);
+    //timer!(TIM12, u16, timx_ker_ck), // TODO: TIM12 seems to be missing for 523's pac, re add once fixed
+}
+
+#[cfg(feature = "h56x_h573")]
+mod h56x_h573 {
+    use super::*;
+    // General-purpose
+    timer!(TIM13: u16, timx_ker_ck);
+    timer!(TIM14: u16, timx_ker_ck);
+    timer!(TIM16: u16, timy_ker_ck);
+    timer!(TIM17: u16, timy_ker_ck);
 }
 
 /// External trait for hardware timers
-pub trait TimerExt<TIM> {
-    type Rec: ResetEnable;
-
+pub trait TimerExt<TIM: Instance> {
     /// Configures a periodic timer
     ///
     /// Generates an overflow event at the `timeout` frequency.
-    fn timer(self, timeout: Hertz, prec: Self::Rec, clocks: &CoreClocks)
-        -> TIM;
+    fn timer(self, timeout: Hertz, prec: TIM::Rec, clocks: &CoreClocks)
+        -> Timer<TIM>;
 
     /// Configures the timer to count up at the given frequency
     ///
@@ -72,9 +165,9 @@ pub trait TimerExt<TIM> {
     fn tick_timer(
         self,
         frequency: Hertz,
-        prec: Self::Rec,
+        prec: TIM::Rec,
         clocks: &CoreClocks,
-    ) -> TIM;
+    ) -> Timer<TIM>;
 }
 
 /// Hardware timers
@@ -85,337 +178,273 @@ pub struct Timer<TIM> {
     tim: TIM,
 }
 
-/// Timer Events
-///
-/// Each event is a possible interrupt source, if enabled
-pub enum Event {
-    /// Timer timed out / count down ended
-    TimeOut,
+impl<TIM: Instance + Basic> TimerExt<TIM> for TIM {
+    fn timer(self, timeout: Hertz,
+                prec: TIM::Rec, clocks: &CoreClocks
+    ) -> Timer<TIM> {
+        let mut timer = Timer::new(self, prec, clocks);
+        timer.start(timeout);
+        timer
+    }
+
+    fn tick_timer(self, frequency: Hertz,
+                     prec: TIM::Rec, clocks: &CoreClocks
+    ) -> Timer<TIM> {
+        let mut timer = Timer::new(self, prec, clocks);
+
+        timer.tick_timer(frequency);
+
+        timer
+    }
 }
 
-macro_rules! hal {
-    ($($TIMX:ident: ($timX:ident, $Rec:ident, $cntType:ty),)+) => {
-        $(
-            impl embedded_hal_02::timer::Periodic for Timer<$TIMX> {}
+impl<TIM: Instance> Timer<TIM> {
+    /// Configures a TIM peripheral as a periodic count down timer,
+    /// without starting it
+    pub fn new(tim: TIM, prec: TIM::Rec, clocks: &CoreClocks) -> Self
+    {
+        // enable and reset peripheral to a clean state
+        let _ = prec.enable().reset(); // drop, can be recreated by free method
 
-            impl embedded_hal_02::timer::CountDown for Timer<$TIMX> {
-                type Time = Hertz;
+        let clk = TIM::clock(clocks).raw();
+            // .expect(concat!(stringify!(TIM), ": Input clock not running!")).raw();
 
-                fn start<T>(&mut self, timeout: T)
+        Timer {
+            clk,
+            tim,
+        }
+    }
+
+    /// Returns a reference to the inner peripheral
+    pub fn inner(&self) -> &TIM {
+        &self.tim
+    }
+
+    /// Returns a mutable reference to the inner peripheral
+    pub fn inner_mut(&mut self) -> &mut TIM {
+        &mut self.tim
+    }
+}
+
+#[allow(private_bounds)]
+impl<TIM: Instance + Basic> Timer<TIM> {
+    /// Configures the timer's frequency and counter reload value
+    /// so that it underflows at the timeout's frequency
+    pub fn set_freq(&mut self, timeout: Hertz) {
+        let ticks = self.clk / timeout.raw();
+
+        self.set_timeout_ticks(ticks);
+    }
+
+    /// Sets the timer period from a time duration
+    ///
+    /// ```
+    /// use stm32h5xx_hal::time::MilliSeconds;
+    ///
+    /// // Set timeout to 100ms
+    /// let timeout = MilliSeconds::from_ticks(100).into_rate();
+    /// timer.set_timeout(timeout);
+    /// ```
+    ///
+    /// Alternatively, the duration can be set using the
+    /// core::time::Duration type
+    ///
+    /// ```
+    /// let duration = core::time::Duration::from_nanos(2_500);
+    ///
+    /// // Set timeout to 2.5µs
+    /// timer.set_timeout(duration);
+    /// ```
+    pub fn set_timeout<T>(&mut self, timeout: T)
+    where
+        T: Into<core::time::Duration>
+    {
+        const NANOS_PER_SECOND: u64 = 1_000_000_000;
+        let timeout = timeout.into();
+
+        let clk = self.clk as u64;
+        let ticks = u32::try_from(
+            clk * timeout.as_secs() +
+            clk * u64::from(timeout.subsec_nanos()) / NANOS_PER_SECOND,
+        )
+        .unwrap_or(u32::MAX);
+
+        self.set_timeout_ticks(ticks.max(1));
+    }
+
+    pub fn start<T>(&mut self, timeout: T)
                 where
                     T: Into<Hertz>,
-                {
-                    // Pause
-                    self.pause();
+    {
+        // Pause
+        self.tim.pause();
 
-                    // Reset counter
-                    self.reset_counter();
+        // Reset counter
+        self.tim.reset_counter();
 
-                    // UEV event occours on next overflow
-                    self.urs_counter_only();
-                    self.clear_irq();
+        // UEV event occours on next overflow
+        self.tim.urs_counter_only();
+        self.tim.clear_timeout_flag();
 
-                    // Set PSC and ARR
-                    self.set_freq(timeout.into());
+        // Set PSC and ARR
+        self.set_freq(timeout.into());
 
-                    // Generate an update event to force an update of the ARR register. This ensures
-                    // the first timer cycle is of the specified duration.
-                    self.apply_freq();
+        // Generate an update event to force an update of the ARR register. This ensures
+        // the first timer cycle is of the specified duration.
+        self.tim.apply_freq();
 
-                    // Start counter
-                    self.resume()
-                }
-
-                fn wait(&mut self) -> nb::Result<(), Void> {
-                    if self.is_irq_clear() {
-                        Err(nb::Error::WouldBlock)
-                    } else {
-                        self.clear_irq();
-                        Ok(())
-                    }
-                }
-            }
-
-            impl TimerExt<Timer<$TIMX>> for $TIMX {
-                type Rec = rec::$Rec;
-
-                fn timer(self, timeout: Hertz,
-                            prec: Self::Rec, clocks: &CoreClocks
-                ) -> Timer<$TIMX> {
-                    use embedded_hal_02::timer::CountDown;
-
-                    let mut timer = Timer::$timX(self, prec, clocks);
-                    timer.start(timeout);
-                    timer
-                }
-
-                fn tick_timer(self, frequency: Hertz,
-                                 prec: Self::Rec, clocks: &CoreClocks
-                ) -> Timer<$TIMX> {
-                    let mut timer = Timer::$timX(self, prec, clocks);
-
-                    timer.pause();
-
-                    // UEV event occours on next overflow
-                    timer.urs_counter_only();
-                    timer.clear_irq();
-
-                    // Set PSC and ARR
-                    timer.set_tick_freq(frequency);
-
-                    // Generate an update event to force an update of the ARR
-                    // register. This ensures the first timer cycle is of the
-                    // specified duration.
-                    timer.apply_freq();
-
-                    // Start counter
-                    timer.resume();
-
-                    timer
-                }
-            }
-
-            impl Timer<$TIMX> {
-                /// Configures a TIM peripheral as a periodic count down timer,
-                /// without starting it
-                pub fn $timX(tim: $TIMX, prec: rec::$Rec, clocks: &CoreClocks) -> Self
-                {
-                    // enable and reset peripheral to a clean state
-                    let _ = prec.enable().reset(); // drop, can be recreated by free method
-
-                    let clk = $TIMX::get_clk(clocks)
-                        .expect(concat!(stringify!($TIMX), ": Input clock not running!")).raw();
-
-                    Timer {
-                        clk,
-                        tim,
-                    }
-                }
-
-                /// Configures the timer's frequency and counter reload value
-                /// so that it underflows at the timeout's frequency
-                pub fn set_freq(&mut self, timeout: Hertz) {
-                    let ticks = self.clk / timeout.raw();
-
-                    self.set_timeout_ticks(ticks);
-                }
-
-                /// Sets the timer period from a time duration
-                ///
-                /// ```
-                /// use stm32h7xx_hal::time::MilliSeconds;
-                ///
-                /// // Set timeout to 100ms
-                /// let timeout = MilliSeconds::from_ticks(100).into_rate();
-                /// timer.set_timeout(timeout);
-                /// ```
-                ///
-                /// Alternatively, the duration can be set using the
-                /// core::time::Duration type
-                ///
-                /// ```
-                /// let duration = core::time::Duration::from_nanos(2_500);
-                ///
-                /// // Set timeout to 2.5µs
-                /// timer.set_timeout(duration);
-                /// ```
-                pub fn set_timeout<T>(&mut self, timeout: T)
-                where
-                    T: Into<core::time::Duration>
-                {
-                    const NANOS_PER_SECOND: u64 = 1_000_000_000;
-                    let timeout = timeout.into();
-
-                    let clk = self.clk as u64;
-                    let ticks = u32::try_from(
-                        clk * timeout.as_secs() +
-                        clk * u64::from(timeout.subsec_nanos()) / NANOS_PER_SECOND,
-                    )
-                    .unwrap_or(u32::MAX);
-
-                    self.set_timeout_ticks(ticks.max(1));
-                }
-
-                /// Sets the timer's prescaler and auto reload register so that the timer will reach
-                /// the ARR after `ticks - 1` amount of timer clock ticks.
-                ///
-                /// ```
-                /// // Set auto reload register to 50000 and prescaler to divide by 2.
-                /// timer.set_timeout_ticks(100000);
-                /// ```
-                ///
-                /// This function will round down if the prescaler is used to extend the range:
-                /// ```
-                /// // Set auto reload register to 50000 and prescaler to divide by 2.
-                /// timer.set_timeout_ticks(100001);
-                /// ```
-                fn set_timeout_ticks(&mut self, ticks: u32) {
-                    let (psc, arr) = calculate_timeout_ticks_register_values(ticks);
-                    unsafe {
-                        self.tim.psc().write(|w| w.psc().bits(psc));
-                    }
-                    #[allow(unused_unsafe)] // method is safe for some timers
-                    self.tim.arr().write(|w| unsafe { w.bits(u32(arr)) });
-                }
-
-                /// Configures the timer to count up at the given frequency
-                ///
-                /// Counts from 0 to the counter's maximum value, then repeats.
-                /// Because this only uses the timer prescaler, the frequency
-                /// is rounded to a multiple of the timer's kernel clock.
-                pub fn set_tick_freq(&mut self, frequency: Hertz) {
-                    let div = self.clk / frequency.raw();
-
-                    let psc = u16(div - 1).unwrap();
-                    unsafe {
-                        self.tim.psc().write(|w| w.psc().bits(psc));
-                    }
-
-                    let counter_max = u32(<$cntType>::MAX);
-                    #[allow(unused_unsafe)] // method is safe for some timers
-                    self.tim.arr().write(|w| unsafe { w.bits(counter_max) });
-                }
-
-                /// Applies frequency/timeout changes immediately
-                ///
-                /// The timer will normally update its prescaler and auto-reload
-                /// value when its counter overflows. This function causes
-                /// those changes to happen immediately. Also clears the counter.
-                pub fn apply_freq(&mut self) {
-                    self.tim.egr().write(|w| w.ug().set_bit());
-                }
-
-                /// Pauses the TIM peripheral
-                pub fn pause(&mut self) {
-                    self.tim.cr1().modify(|_, w| w.cen().clear_bit());
-                }
-
-                /// Resume (unpause) the TIM peripheral
-                pub fn resume(&mut self) {
-                    self.tim.cr1().modify(|_, w| w.cen().set_bit());
-                }
-
-                /// Set Update Request Source to counter overflow/underflow only
-                pub fn urs_counter_only(&mut self) {
-                    self.tim.cr1().modify(|_, w| w.urs().counter_only());
-                }
-
-                /// Reset the counter of the TIM peripheral
-                pub fn reset_counter(&mut self) {
-                    self.tim.cnt().reset();
-                }
-
-                /// Read the counter of the TIM peripheral
-                pub fn counter(&self) -> u32 {
-                    self.tim.cnt().read().cnt().bits().into()
-                }
-
-                /// Start listening for `event`
-                pub fn listen(&mut self, event: Event) {
-                    match event {
-                        Event::TimeOut => {
-                            // Enable update event interrupt
-                            self.tim.dier().write(|w| w.uie().set_bit());
-                        }
-                    }
-                }
-
-                /// Stop listening for `event`
-                pub fn unlisten(&mut self, event: Event) {
-                    match event {
-                        Event::TimeOut => {
-                            // Disable update event interrupt
-                            self.tim.dier().write(|w| w.uie().clear_bit());
-                            let _ = self.tim.dier().read();
-                            let _ = self.tim.dier().read(); // Delay 2 peripheral clocks
-                        }
-                    }
-                }
-
-                /// Check if Update Interrupt flag is cleared
-                pub fn is_irq_clear(&mut self) -> bool {
-                    self.tim.sr().read().uif().bit_is_clear()
-                }
-
-                /// Clears interrupt flag
-                pub fn clear_irq(&mut self) {
-                    self.tim.sr().modify(|_, w| {
-                        // Clears timeout event
-                        w.uif().clear_bit()
-                    });
-                    let _ = self.tim.sr().read();
-                    let _ = self.tim.sr().read(); // Delay 2 peripheral clocks
-                }
-
-                /// Releases the TIM peripheral
-                pub fn free(mut self) -> ($TIMX, rec::$Rec) {
-                    // pause counter
-                    self.pause();
-
-                    (self.tim, rec::$Rec { _marker: PhantomData })
-                }
-
-                /// Returns a reference to the inner peripheral
-                pub fn inner(&self) -> &$TIMX {
-                    &self.tim
-                }
-
-                /// Returns a mutable reference to the inner peripheral
-                pub fn inner_mut(&mut self) -> &mut $TIMX {
-                    &mut self.tim
-                }
-            }
-        )+
+        // Start counter
+        self.tim.resume()
     }
+
+    /// Check whether the timeout has occurred and clear status flags if it has
+    pub fn check_clear_timeout(&mut self) -> bool {
+        if self.tim.is_timeout_complete() {
+            self.tim.clear_timeout_flag();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Blocks until timeout occurs
+    pub fn wait_for_timeout(&mut self) {
+        while !self.check_clear_timeout() {}
+    }
+
+    fn tick_timer(&mut self, frequency: Hertz) {
+        self.tim.pause();
+
+        // UEV event occours on next overflow
+        self.tim.urs_counter_only();
+        self.tim.clear_timeout_flag();
+
+        // Set PSC and ARR
+        self.set_tick_freq(frequency);
+
+        // Generate an update event to force an update of the ARR
+        // register. This ensures the first timer cycle is of the
+        // specified duration.
+        self.tim.apply_freq();
+
+        // Start counter
+        self.tim.resume();
+    }
+
+    /// Sets the timer's prescaler and auto reload register so that the timer will reach
+    /// the ARR after `ticks - 1` amount of timer clock ticks.
+    ///
+    /// ```
+    /// // Set auto reload register to 50000 and prescaler to divide by 2.
+    /// timer.set_timeout_ticks(100000);
+    /// ```
+    ///
+    /// This function will round down if the prescaler is used to extend the range:
+    /// ```
+    /// // Set auto reload register to 50000 and prescaler to divide by 2.
+    /// timer.set_timeout_ticks(100001);
+    /// ```
+    fn set_timeout_ticks(&mut self, ticks: u32) {
+        let (psc, arr) = calculate_timeout_ticks_register_values(ticks);
+        self.tim.set_prescalar(psc.into());
+        self.tim.set_arr(arr.into());
+    }
+
+    /// Configures the timer to count up at the given frequency
+    ///
+    /// Counts from 0 to the counter's maximum value, then repeats.
+    /// Because this only uses the timer prescaler, the frequency
+    /// is rounded to a multiple of the timer's kernel clock.
+    pub fn set_tick_freq(&mut self, frequency: Hertz) {
+        let div = self.clk / frequency.raw();
+
+        // TODO: This only works for frequencies high enough to result in a 16-bit divisor. Consider removing
+        let psc = u16::try_from(div - 1).unwrap();
+        self.tim.set_prescalar(psc);
+
+        let counter_max = TIM::Counter::MAX;
+        self.tim.set_arr(counter_max);
+    }
+
+    /// Enable timeout interrupt. This maps to the Update Event timeout
+    pub fn enable_timeout_interrupt(&mut self) {
+        self.tim.enable_timeout_interrupt();
+    }
+
+    /// Disable timeout interrupt. This maps to the Update Event timeout
+    pub fn disable_timeout_interrupt(&mut self) {
+        self.tim.disable_timeout_interrupt();
+    }
+
+    /// Releases the TIM peripheral
+    pub fn free(mut self) -> (TIM, TIM::Rec) {
+        // pause counter
+        self.tim.pause();
+        self.tim.disable_timeout_interrupt();
+
+        (self.tim, TIM::rec())
+    }
+}
+
+/// The Basic trait represents functionality common to all timers (Basic, General Purpose, and
+/// Advanced-control Timers), as described in RM0492 and RM0481. It facilitates basic timeout
+/// operations which are exposed on the [`Timer`] instance for all TIM peripherals.
+trait Basic {
+    type Counter: Counter;
+    fn set_prescalar(&mut self, psc: u16);
+
+    fn set_arr(&mut self, arr: Self::Counter);
+
+    /// Applies frequency/timeout changes immediately
+    ///
+    /// The timer will normally update its prescaler and auto-reload
+    /// value when its counter overflows. This function causes
+    /// those changes to happen immediately. Also clears the counter.
+    fn apply_freq(&mut self);
+
+    /// Pauses the TIM peripheral
+    fn pause(&mut self);
+
+    /// Resume (unpause) the TIM peripheral
+    fn resume(&mut self);
+
+    /// Set Update Request Source to counter overflow/underflow only
+    fn urs_counter_only(&mut self);
+
+    /// Reset the counter of the TIM peripheral
+    fn reset_counter(&mut self);
+
+    /// Enable timeout interrupt for
+    fn enable_timeout_interrupt(&mut self);
+
+    fn disable_timeout_interrupt(&mut self);
+
+    /// Check if Update Interrupt flag is cleared
+    fn is_timeout_complete(&mut self) -> bool;
+
+    /// Clears interrupt flag
+    fn clear_timeout_flag(&mut self);
 }
 
 /// We want to have `ticks` amount of timer ticks before it reloads.
 /// But `ticks` may have a higher value than what the timer can hold directly.
 /// So we'll use the prescaler to extend the range.
 ///
-/// To know how many times we would overflow with a prescaler of 1, we divide `ticks` by 2^16 (the max amount of ticks per overflow).
-/// If the result is e.g. 3, then we need to increase our range by 4 times to fit all the ticks.
-/// We can increase the range enough by setting the prescaler to 3 (which will divide the clock freq by 4).
-/// Because every tick is now 4x as long, we need to divide `ticks` by 4 to keep the same timeout.
+/// To know how many times we would overflow with a prescaler of 1, we divide `ticks` by 2^(bit
+/// width of the counter), the max amount of ticks per overflow. E.g: if the result is e.g. 3,
+/// then we need to increase our range by 4 times to fit all the ticks. We can increase the range
+/// enough by setting the prescaler to 3 (which will divide the clock freq by 4). Because every
+/// tick is now 4x as long, we need to divide `ticks` by 4 to keep the same timeout.
 ///
 /// This function returns the prescaler register value and auto reload register value.
 fn calculate_timeout_ticks_register_values(ticks: u32) -> (u16, u16) {
     // Note (unwrap): Never panics because 32-bit value is shifted right by 16 bits,
     // resulting in a value that always fits in 16 bits.
-    let psc = u16(ticks / (1 << 16)).unwrap();
+    let psc = (ticks / (1 << u16::BITS)).try_into().unwrap();
     // Note (unwrap): Never panics because the divisor is always such that the result fits in 16 bits.
     // Also note that the timer counts `0..=arr`, so subtract 1 to get the correct period.
-    let arr = u16(ticks / (u32(psc) + 1)).unwrap().saturating_sub(1);
+    let arr = u16::try_from(ticks / ((psc as u32) + 1)).unwrap().saturating_sub(1);
     (psc, arr)
-}
-
-hal! {
-    // Advanced-control
-    TIM1: (tim1, Tim1, u16),
-
-    // General-purpose
-    TIM2: (tim2, Tim2, u32),
-    TIM3: (tim3, Tim3, u16),
-
-    // Basic
-    TIM6: (tim6, Tim6, u16),
-    TIM7: (tim7, Tim7, u16),
-}
-
-#[cfg(feature = "rm0481")]
-hal! {
-    // Advanced-control
-    TIM8: (tim8, Tim8, u16),
-
-    // General-purpose
-    TIM4: (tim4, Tim4, u16),
-    TIM5: (tim5, Tim5, u32),
-
-    // General-purpose
-    //TIM12: (tim12, Tim12, u16), // TODO: TIM12 seems to be missing for 523's pac, re add once fixed
-
-    // General-purpose
-    TIM15: (tim15, Tim15, u16),
 }
 
 #[cfg(test)]

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -55,9 +55,8 @@ macro_rules! timer {
         impl Basic for $TIMX {
             type Counter = $cntType;
             fn set_prescalar(&mut self, psc: u16) {
-                unsafe {
-                    self.psc().write(|w| w.psc().bits(psc));
-                }
+                self.psc().write(|w| w.psc().set(psc));
+
             }
 
             fn set_arr(&mut self, arr: Self::Counter) {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -65,7 +65,9 @@ pub use counters::{Tick, Timeout};
 /// Counter represents the word type used for setting the period of timer.
 /// Consult RM0492/RM0481 for which timer supports which word sizes.
 #[doc(hidden)]
-pub trait Counter: crate::Sealed + Into<u32> + TryFrom<u32> + From<u16> + Debug {
+pub trait Counter:
+    crate::Sealed + Into<u32> + TryFrom<u32> + From<u16> + Debug
+{
     const MAX: Self;
 }
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -9,6 +9,8 @@ use core::marker::PhantomData;
 use crate::stm32::{TIM1, TIM2, TIM3, TIM6, TIM7};
 #[cfg(feature = "rm0481")]
 use crate::stm32::{/*TIM12,*/ TIM15, TIM4, TIM5, TIM8}; // TODO: TIM12 seems to be missing for 523's pac, re add once fixed
+#[cfg(feature = "h56x_h573")]
+use crate::stm32::{TIM13, TIM14, TIM16, TIM17};
 
 use crate::rcc::{rec, CoreClocks, ResetEnable};
 use crate::time::Hertz;

--- a/src/timer/counters.rs
+++ b/src/timer/counters.rs
@@ -91,7 +91,7 @@ impl<TIM: Instance + Basic> Timeout<TIM> {
         self.start(ticks);
     }
 
-    /// Convert into [`Tick`] timer.
+    /// Convert into [`Tick`] timer. Cancels any ongoing operation.
     pub fn into_tick_timer(mut self) -> Tick<TIM> {
         self.cancel();
         self.0.tick()
@@ -126,6 +126,7 @@ impl<TIM> DerefMut for Tick<TIM> {
 }
 
 impl<TIM: Instance + Basic> Tick<TIM> {
+    /// Start the tick timer
     pub fn start<T>(&mut self, frequency_hz: T)
     where
         T: Into<Hertz>,
@@ -163,7 +164,7 @@ impl<TIM: Instance + Basic> Tick<TIM> {
         self.tim.set_auto_reload(TIM::Counter::MAX);
     }
 
-    /// Convert to [`Timeout`] timer
+    /// Convert to [`Timeout`] timer. Cancels any ongoing operation.
     pub fn into_timeout_timer(mut self) -> Timeout<TIM> {
         self.cancel();
         self.0.timeout()

--- a/src/timer/counters.rs
+++ b/src/timer/counters.rs
@@ -153,7 +153,9 @@ impl<TIM: Instance + Basic> Tick<TIM> {
     ///
     /// Counts from 0 to the counter's maximum value, then repeats.
     /// Because this only uses the timer prescaler, the frequency
-    /// is rounded to a multiple of the timer's kernel clock.
+    /// is rounded up to an integer fraction of the timer's kernel
+    /// clock. (ie. specifying 300kHz with a 1MHz kernel clock will
+    /// result in a tick frequency of 1MHz/3 = 333kHz)
     fn set_tick_frequency(&mut self, frequency: Hertz) {
         let div = self.clk / frequency.raw();
 

--- a/src/timer/counters.rs
+++ b/src/timer/counters.rs
@@ -1,0 +1,176 @@
+use core::ops::{Deref, DerefMut};
+
+use crate::time::{Hertz, NanoSeconds};
+
+use super::{Basic, Counter, Instance, Timer};
+
+/// Timeout timer
+///
+/// Used to trigger overflow events on the timer at the specified frequency or timeout
+/// values.
+/// - Use [`Timeout::start_with_frequency`] to trigger events at the given frequency
+/// - Use [`Timeout::start_with_timeout`] to trigger events after the given timeout period
+///
+/// To wait on the overflow event use [`wait_for_overflow`](Timer::wait_for_overflow)
+pub struct Timeout<TIM>(Timer<TIM>);
+
+impl<TIM> Timeout<TIM> {
+    pub(super) fn new(timer: Timer<TIM>) -> Self {
+        Self(timer)
+    }
+}
+
+impl<TIM> Deref for Timeout<TIM> {
+    type Target = Timer<TIM>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<TIM> DerefMut for Timeout<TIM> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+#[allow(private_bounds)]
+impl<TIM: Instance + Basic> Timeout<TIM> {
+    fn start(&mut self, ticks: u32) {
+        // Pause
+        self.tim.pause();
+
+        // Reset counter
+        self.tim.reset_counter();
+
+        // UEV event occours on next overflow
+        self.tim.urs_counter_only();
+        self.tim.clear_timeout_flag();
+
+        // Set PSC and ARR
+        self.set_timeout_ticks(ticks);
+
+        // Generate an update event to force an update of the ARR register. This ensures
+        // the first timer cycle is of the specified duration.
+        self.tim.apply_freq();
+
+        // Start counter
+        self.tim.resume()
+    }
+
+    /// Start the timer so that it overflows at the given frequency
+    ///
+    /// # Example
+    /// ```
+    /// timer.start_with_frequency(1.kHz())
+    /// ```
+    pub fn start_with_frequency<T>(&mut self, frequency: T)
+    where
+        T: Into<Hertz>,
+    {
+        let frequency: Hertz = frequency.into();
+        let ticks = self.clk / frequency.raw();
+        self.start(ticks);
+    }
+
+    /// Start the timer so that it repeatedly overflows after the specified timeout
+    ///
+    /// # Example
+    /// ```
+    /// timer.start_with_timeout(1.millis())
+    /// ```
+    pub fn start_with_timeout<T>(&mut self, timeout_ns: T)
+    where
+        T: Into<NanoSeconds>,
+    {
+        let timeout: NanoSeconds = timeout_ns.into();
+        let clk = Hertz::from_raw(self.clk);
+        let clk_period: NanoSeconds = clk.into_duration();
+
+        let ticks = timeout / clk_period;
+        self.start(ticks);
+    }
+
+    /// Convert into [`Tick`] timer.
+    pub fn into_tick_timer(mut self) -> Tick<TIM> {
+        self.cancel();
+        self.0.tick()
+    }
+
+    /// Cancels the timer and releases the TIM peripheral
+    pub fn free(self) -> (TIM, TIM::Rec) {
+        self.0.free()
+    }
+}
+
+pub struct Tick<TIM>(Timer<TIM>);
+
+impl<TIM> Tick<TIM> {
+    pub(super) fn new(timer: Timer<TIM>) -> Self {
+        Self(timer)
+    }
+}
+
+impl<TIM> Deref for Tick<TIM> {
+    type Target = Timer<TIM>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<TIM> DerefMut for Tick<TIM> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<TIM: Instance + Basic> Tick<TIM> {
+    pub fn start<T>(&mut self, frequency_hz: T)
+    where
+        T: Into<Hertz>,
+    {
+        self.tim.pause();
+
+        // UEV event occours on next overflow
+        self.tim.urs_counter_only();
+        self.tim.clear_timeout_flag();
+
+        // Set PSC and ARR
+        self.set_tick_frequency(frequency_hz.into());
+
+        // Generate an update event to force an update of the ARR
+        // register. This ensures the first timer cycle is of the
+        // specified duration.
+        self.tim.apply_freq();
+
+        // Start counter
+        self.tim.resume();
+    }
+
+    /// Configures the timer to count up at the given frequency
+    ///
+    /// Counts from 0 to the counter's maximum value, then repeats.
+    /// Because this only uses the timer prescaler, the frequency
+    /// is rounded to a multiple of the timer's kernel clock.
+    fn set_tick_frequency(&mut self, frequency: Hertz) {
+        let div = self.clk / frequency.raw();
+
+        // TODO: This only works for frequencies high enough to result in a 16-bit divisor. Consider removing
+        let psc = u16::try_from(div - 1).unwrap();
+        self.tim.set_prescalar(psc);
+
+        self.tim.set_auto_reload(TIM::Counter::MAX);
+    }
+
+    /// Convert to [`Timeout`] timer
+    pub fn into_timeout_timer(mut self) -> Timeout<TIM> {
+        self.cancel();
+        self.0.timeout()
+    }
+
+    /// Cancels the timer and releases the TIM peripheral
+    pub fn free(self) -> (TIM, TIM::Rec) {
+        self.0.free()
+    }
+}

--- a/src/timer/timer_def.rs
+++ b/src/timer/timer_def.rs
@@ -1,0 +1,125 @@
+use core::marker::PhantomData;
+
+use crate::rcc::{rec, CoreClocks};
+use crate::stm32::{TIM1, TIM2, TIM3, TIM6, TIM7};
+#[cfg(feature = "rm0481")]
+use crate::stm32::{TIM12, TIM15, TIM4, TIM5, TIM8};
+#[cfg(feature = "h56x_h573")]
+use crate::stm32::{TIM13, TIM14, TIM16, TIM17};
+use crate::time::Hertz;
+
+use super::{Basic, Instance};
+
+macro_rules! timer {
+    ($TIMX:ident: $cntType:ty, $ker_ck:ident) => {
+        paste::item! {
+            impl crate::Sealed for $TIMX {}
+
+            impl Instance for $TIMX {
+                type Rec = rec::[< $TIMX:lower:camel >];
+
+                fn clock(clocks: &CoreClocks) -> Hertz {
+                    clocks.$ker_ck()
+                }
+
+                fn rec() -> Self::Rec {
+                    rec::[< $TIMX:lower:camel >] { _marker: PhantomData }
+                }
+            }
+
+            impl Basic for $TIMX {
+                type Counter = $cntType;
+                fn set_prescalar(&mut self, psc: u16) {
+                    self.psc().write(|w| w.psc().set(psc));
+                }
+
+                fn set_auto_reload(&mut self, arr: Self::Counter) {
+                    self.arr().write(|w| w.arr().set(arr.into()));
+                }
+
+                fn apply_freq(&mut self) {
+                    self.egr().write(|w| w.ug().update());
+                }
+
+                fn pause(&mut self) {
+                    self.cr1().modify(|_, w| w.cen().disabled());
+                }
+
+                fn resume(&mut self) {
+                    self.cr1().modify(|_, w| w.cen().enabled());
+                }
+
+                fn urs_counter_only(&mut self) {
+                    self.cr1().modify(|_, w| w.urs().counter_only());
+                }
+
+                /// Reset the counter of the TIM peripheral
+                fn reset_counter(&mut self) {
+                    self.cnt().reset();
+                }
+
+                fn counter(&self) -> Self::Counter {
+                    self.cnt().read().cnt().bits()
+                }
+
+                fn enable_timeout_interrupt(&mut self) {
+                    // Enable update event interrupt
+                    self.dier().write(|w| w.uie().enabled());
+                }
+
+                fn disable_timeout_interrupt(&mut self) {
+                    self.dier().write(|w| w.uie().disabled());
+                    interrupt_clear_clock_sync_delay!(self.dier());
+                }
+
+
+                fn is_timeout_complete(&self) -> bool {
+                    self.sr().read().uif().is_update_pending()
+                }
+
+                /// Clears interrupt flag
+                fn clear_timeout_flag(&mut self) {
+                    self.sr().modify(|_, w| {
+                        // Clears timeout event
+                        w.uif().clear()
+                    });
+                    interrupt_clear_clock_sync_delay!(self.sr());
+                }
+            }
+        }
+    };
+}
+
+// Advanced Control
+timer!(TIM1: u16, timy_ker_ck);
+
+// General-purpose
+timer!(TIM2: u32, timx_ker_ck);
+timer!(TIM3: u16, timx_ker_ck);
+
+// Basic
+timer!(TIM6: u16, timx_ker_ck);
+timer!(TIM7: u16, timx_ker_ck);
+
+#[cfg(feature = "rm0481")]
+mod rm0481 {
+    use super::*;
+    // Advanced-control
+    timer!(TIM8: u16, timy_ker_ck);
+
+    // General-purpose
+    timer!(TIM4: u16, timx_ker_ck);
+    timer!(TIM5: u32, timx_ker_ck);
+    timer!(TIM15: u16, timy_ker_ck);
+    timer!(TIM12: u16, timx_ker_ck);
+}
+
+#[cfg(feature = "h56x_h573")]
+mod h56x_h573 {
+    use super::*;
+    // General-purpose
+    timer!(TIM13: u16, timx_ker_ck);
+    timer!(TIM14: u16, timx_ker_ck);
+    timer!(TIM16: u16, timy_ker_ck);
+    timer!(TIM17: u16, timy_ker_ck);
+}

--- a/src/timer/timer_def.rs
+++ b/src/timer/timer_def.rs
@@ -1,9 +1,13 @@
 use core::marker::PhantomData;
 
 use crate::rcc::{rec, CoreClocks};
+#[cfg(all(feature = "rm0481", not(feature = "stm32h523")))]
+// TIM12 is not defined in the PAC for STM32H523. Remove this compiler switch when it is.
+use crate::stm32::TIM12;
 use crate::stm32::{TIM1, TIM2, TIM3, TIM6, TIM7};
 #[cfg(feature = "rm0481")]
-use crate::stm32::{TIM12, TIM15, TIM4, TIM5, TIM8};
+use crate::stm32::{TIM15, TIM4, TIM5, TIM8};
+
 #[cfg(feature = "h56x_h573")]
 use crate::stm32::{TIM13, TIM14, TIM16, TIM17};
 use crate::time::Hertz;
@@ -111,6 +115,7 @@ mod rm0481 {
     timer!(TIM4: u16, timx_ker_ck);
     timer!(TIM5: u32, timx_ker_ck);
     timer!(TIM15: u16, timy_ker_ck);
+    #[cfg(not(feature = "stm32h523"))]
     timer!(TIM12: u16, timx_ker_ck);
 }
 


### PR DESCRIPTION
This implements timer functionality for the H5 family. It implements functionality that is common to all timers on all MCUs in the family (although it does not implement any LPTIM peripherals). It builds on top of #59, but instead of using macros to define all timer methods, this instead defines traits that represent just the functionality exposed for basic timer operation (inspired by how the STM32F4 HAL is structured), and uses macros to implement those limited methods. This keeps the macro surface area minimized. Future development can define Traits for General and Advanced timers to add in functionality for those timer peripherals.