### PR TITLE
Initialize I2C peripheral with custom timing value

### DIFF
--- a/examples/i2c.rs
+++ b/examples/i2c.rs
@@ -6,12 +6,7 @@
 mod utilities;
 use embedded_hal::{delay::DelayNs, i2c::I2c};
 use fugit::SecsDurationU32;
-use stm32h5xx_hal::{
-    delay::Delay,
-    i2c::Instance,
-    pac,
-    prelude::*,
-};
+use stm32h5xx_hal::{delay::Delay, pac, prelude::*};
 
 use cortex_m_rt::entry;
 
@@ -48,8 +43,12 @@ fn main() -> ! {
     info!("");
 
     let bus_freq_hz = 100.kHz();
-    let i2c_ker_ck = pac::I2C2::clock(&ccdr.clocks);
-    let mut i2c = dp.I2C2.i2c((scl, sda), (i2c_ker_ck, bus_freq_hz), ccdr.peripheral.I2C2);
+    let mut i2c = dp.I2C2.i2c(
+        (scl, sda),
+        bus_freq_hz,
+        ccdr.peripheral.I2C2,
+        &ccdr.clocks,
+    );
 
     // The STM32H503 NUCLEO board does not have any I2C peripherals, so put in the address of
     // whatever peripheral you connect

--- a/examples/i2c.rs
+++ b/examples/i2c.rs
@@ -6,7 +6,12 @@
 mod utilities;
 use embedded_hal::{delay::DelayNs, i2c::I2c};
 use fugit::SecsDurationU32;
-use stm32h5xx_hal::{delay::Delay, pac, prelude::*};
+use stm32h5xx_hal::{
+    delay::Delay,
+    i2c::Instance,
+    pac,
+    prelude::*,
+};
 
 use cortex_m_rt::entry;
 
@@ -42,9 +47,9 @@ fn main() -> ! {
     info!("stm32h5xx-hal example - I2C");
     info!("");
 
-    let mut i2c =
-        dp.I2C2
-            .i2c((scl, sda), 100.kHz(), ccdr.peripheral.I2C2, &ccdr.clocks);
+    let bus_freq_hz = 100.kHz();
+    let i2c_ker_ck = pac::I2C2::clock(&ccdr.clocks);
+    let mut i2c = dp.I2C2.i2c((scl, sda), (i2c_ker_ck, bus_freq_hz), ccdr.peripheral.I2C2);
 
     // The STM32H503 NUCLEO board does not have any I2C peripherals, so put in the address of
     // whatever peripheral you connect

--- a/examples/i2c_target.rs
+++ b/examples/i2c_target.rs
@@ -5,7 +5,7 @@
 #[macro_use]
 mod utilities;
 use stm32h5xx_hal::{
-    i2c::{Instance, TargetConfig, TargetListenEvent, Targetable},
+    i2c::{TargetConfig, TargetListenEvent, Targetable},
     pac,
     prelude::*,
 };
@@ -42,13 +42,13 @@ fn main() -> ! {
 
     let own_addr: u16 = 0x18;
     let bus_freq_hz = 100.kHz();
-    let i2c_ker_ck = pac::I2C2::clock(&ccdr.clocks);
 
     let mut i2c = dp.I2C2.i2c_target_only(
         (scl, sda),
-        (i2c_ker_ck, bus_freq_hz),
+        bus_freq_hz,
         TargetConfig::new(own_addr),
         ccdr.peripheral.I2C2,
+        &ccdr.clocks,
     );
 
     i2c.enable_listen_event(TargetListenEvent::PrimaryAddress);

--- a/examples/i2c_target.rs
+++ b/examples/i2c_target.rs
@@ -5,7 +5,7 @@
 #[macro_use]
 mod utilities;
 use stm32h5xx_hal::{
-    i2c::{TargetConfig, TargetListenEvent, Targetable},
+    i2c::{Instance, TargetConfig, TargetListenEvent, Targetable},
     pac,
     prelude::*,
 };
@@ -41,12 +41,14 @@ fn main() -> ! {
     info!("");
 
     let own_addr: u16 = 0x18;
-    let bus_freq_hz: u32 = 100_000;
+    let bus_freq_hz = 100.kHz();
+    let i2c_ker_ck = pac::I2C2::clock(&ccdr.clocks);
+
     let mut i2c = dp.I2C2.i2c_target_only(
         (scl, sda),
-        TargetConfig::new(own_addr, bus_freq_hz),
+        (i2c_ker_ck, bus_freq_hz),
+        TargetConfig::new(own_addr),
         ccdr.peripheral.I2C2,
-        &ccdr.clocks,
     );
 
     i2c.enable_listen_event(TargetListenEvent::PrimaryAddress);

--- a/examples/i2c_target_manual_ack.rs
+++ b/examples/i2c_target_manual_ack.rs
@@ -5,7 +5,7 @@
 #[macro_use]
 mod utilities;
 use stm32h5xx_hal::{
-    i2c::{Instance, TargetConfig, TargetEvent, TargetListenEvent, Targetable},
+    i2c::{TargetConfig, TargetEvent, TargetListenEvent, Targetable},
     pac,
     prelude::*,
 };
@@ -42,14 +42,14 @@ fn main() -> ! {
 
     let own_addr: u16 = 0x18;
     let bus_freq_hz = 100.kHz();
-    let i2c_ker_ck = pac::I2C2::clock(&ccdr.clocks);
     let mut i2c = dp
         .I2C2
         .i2c_target_only(
             (scl, sda),
-            (i2c_ker_ck, bus_freq_hz),
+            bus_freq_hz,
             TargetConfig::new(own_addr),
             ccdr.peripheral.I2C2,
+            &ccdr.clocks,
         )
         .with_manual_ack_control();
 

--- a/examples/i2c_target_manual_ack.rs
+++ b/examples/i2c_target_manual_ack.rs
@@ -5,7 +5,7 @@
 #[macro_use]
 mod utilities;
 use stm32h5xx_hal::{
-    i2c::{TargetConfig, TargetEvent, TargetListenEvent, Targetable},
+    i2c::{Instance, TargetConfig, TargetEvent, TargetListenEvent, Targetable},
     pac,
     prelude::*,
 };
@@ -41,14 +41,15 @@ fn main() -> ! {
     info!("");
 
     let own_addr: u16 = 0x18;
-    let bus_freq_hz: u32 = 100_000;
+    let bus_freq_hz = 100.kHz();
+    let i2c_ker_ck = pac::I2C2::clock(&ccdr.clocks);
     let mut i2c = dp
         .I2C2
         .i2c_target_only(
             (scl, sda),
-            TargetConfig::new(own_addr, bus_freq_hz),
+            (i2c_ker_ck, bus_freq_hz),
+            TargetConfig::new(own_addr),
             ccdr.peripheral.I2C2,
-            &ccdr.clocks,
         )
         .with_manual_ack_control();
 

--- a/src/gpdma/config.rs
+++ b/src/gpdma/config.rs
@@ -371,10 +371,7 @@ impl<T: HardwareRequest, S: Word, D: Word> DmaConfig<T, S, D> {
 
 #[cfg(test)]
 mod test {
-    use crate::gpdma::{
-        config::{self, MemoryToMemory},
-        DmaConfig,
-    };
+    use crate::gpdma::{config::MemoryToMemory, DmaConfig};
 
     use super::*;
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -61,7 +61,8 @@
 //!
 //! let mut i2c_target = dp.I2C1.i2c_target_only(
 //!     (scl, sda),
-//!     TargetConfig::new(own_addr, bus_freq),
+//!     bus_freq,
+//!     TargetConfig::new(own_addr),
 //!     ccdr.peripheral.I2C1,
 //! );
 //! ```
@@ -125,7 +126,8 @@
 //!
 //! let mut i2c = dp.I2C1.i2c_controller_target(
 //!     (scl, sda),
-//!     TargetConfig::new(own_addr, bus_freq),
+//!     bus_freq,
+//!     TargetConfig::new(own_addr),
 //!     ccdr.peripheral.I2C1,
 //! );
 //! ```
@@ -318,13 +320,7 @@ pub struct ManualAck;
 /// Marker struct for I2cTarget implementation to indicate that it automatically handles all ACK'ing
 pub struct AutoAck;
 
-/// A raw pre-computed TIMINGR register value.
-///
-/// Wraps a `u32` to distinguish it from a bus frequency when passing to
-/// [`I2c::new`] or the [`I2cExt`] constructors. Obtain a value from STM32CubeMX
-/// or AN4235 and wrap it here to bypass runtime timing calculation.
-#[derive(Debug, Clone, Copy)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+/// A raw u32 representation of the TIMINGR register, which can be converted into an I2cTiming struct.
 pub struct RawTimingr(pub u32);
 
 /// Represents the TIMINGR register and its associated timing parameters for an I2C peripheral.
@@ -332,7 +328,7 @@ pub struct RawTimingr(pub u32);
 /// or calculated at runtime from the peripheral clock and target bus frequency.
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct TimingRegister {
+pub struct I2cTiming {
     presc: u8,
     scldel: u8,
     sdadel: u8,
@@ -389,143 +385,118 @@ impl<I2C> Inner<I2C> {
 
 pub trait I2cExt<I2C: Instance>: Sized {
     /// Create a I2c instance that is capable of Controller operation only
-    fn i2c<P: Pins<I2C>, T: IntoTimingRegister>(
+    fn i2c<P: Pins<I2C>, T: IntoI2cTiming>(
         self,
         _pins: P,
         timing: T,
         rec: I2C::Rec,
-        clocks: &CoreClocks,
     ) -> I2c<I2C, SingleRole>;
 
     /// Create a I2c instance that is capable of Controller operation only.
     /// This will not check that the pins are properly configured.
-    fn i2c_unchecked<T: IntoTimingRegister>(
+    fn i2c_unchecked<T: IntoI2cTiming>(
         self,
         timing: T,
         rec: I2C::Rec,
-        clocks: &CoreClocks,
     ) -> I2c<I2C, SingleRole>;
 
     /// Create an I2cTarget instance capable of Target operation only
-    fn i2c_target_only<P: Pins<I2C>, T: IntoTimingRegister>(
+    fn i2c_target_only<P: Pins<I2C>, T: IntoI2cTiming>(
         self,
         _pins: P,
-        target_config: TargetConfig<T>,
+        timing: T,
+        target_config: TargetConfig,
         rec: I2C::Rec,
-        clocks: &CoreClocks,
     ) -> I2cTarget<I2C, AutoAck, SingleRole>;
 
     /// Create an I2cTarget instance capable of Target operation only.
     /// This will not check that the pins are properly configured.
-    fn i2c_target_only_unchecked<T: IntoTimingRegister>(
+    fn i2c_target_only_unchecked<T: IntoI2cTiming>(
         self,
-        target_config: TargetConfig<T>,
+        timing: T,
+        target_config: TargetConfig,
         rec: I2C::Rec,
-        clocks: &CoreClocks,
     ) -> I2cTarget<I2C, AutoAck, SingleRole>;
 
     /// Create an I2c instance that can switch roles to a I2cTarget to perform
     /// Target operations
-    fn i2c_controller_target<
-        P: Pins<I2C>,
-        T: IntoTimingRegister,
-        CT: IntoTimingRegister,
-    >(
+    fn i2c_controller_target<P: Pins<I2C>, T: IntoI2cTiming>(
         self,
         _pins: P,
         timing: T,
-        target_config: TargetConfig<CT>,
+        target_config: TargetConfig,
         rec: I2C::Rec,
-        clocks: &CoreClocks,
     ) -> I2c<I2C, SwitchRole>;
 
     /// Create an I2c instance that can switch roles to a I2cTarget to perform
     /// Target operations.
     /// This will not check that the pins are properly configured.
-    fn i2c_controller_target_unchecked<
-        T: IntoTimingRegister,
-        CT: IntoTimingRegister,
-    >(
+    fn i2c_controller_target_unchecked<T: IntoI2cTiming>(
         self,
         timing: T,
-        target_config: TargetConfig<CT>,
+        target_config: TargetConfig,
         rec: I2C::Rec,
-        clocks: &CoreClocks,
     ) -> I2c<I2C, SwitchRole>;
 }
 
 impl<I2C: Instance> I2cExt<I2C> for I2C {
-    fn i2c<P: Pins<I2C>, T: IntoTimingRegister>(
+    fn i2c<P: Pins<I2C>, T: IntoI2cTiming>(
         self,
         _pins: P,
         timing: T,
         rec: I2C::Rec,
-        clocks: &CoreClocks,
     ) -> I2c<I2C, SingleRole> {
-        I2c::new(self, timing, None::<TargetConfig<Hertz>>, rec, clocks)
+        I2c::new(self, timing.into_i2c_timing(), None::<TargetConfig>, rec)
     }
 
-    fn i2c_unchecked<T: IntoTimingRegister>(
+    fn i2c_unchecked<T: IntoI2cTiming>(
         self,
         timing: T,
         rec: I2C::Rec,
-        clocks: &CoreClocks,
     ) -> I2c<I2C, SingleRole> {
-        I2c::new(self, timing, None::<TargetConfig<Hertz>>, rec, clocks)
+        I2c::new(self, timing.into_i2c_timing(), None::<TargetConfig>, rec)
     }
 
-    fn i2c_target_only<P: Pins<I2C>, T: IntoTimingRegister>(
-        self,
-        _pins: P,
-        config: TargetConfig<T>,
-        rec: I2C::Rec,
-        clocks: &CoreClocks,
-    ) -> I2cTarget<I2C, AutoAck, SingleRole> {
-        I2cTarget::new(self, config, rec, clocks)
-    }
-
-    fn i2c_target_only_unchecked<T: IntoTimingRegister>(
-        self,
-        target_config: TargetConfig<T>,
-        rec: I2C::Rec,
-        clocks: &CoreClocks,
-    ) -> I2cTarget<I2C, AutoAck, SingleRole> {
-        I2cTarget::new(self, target_config, rec, clocks)
-    }
-
-    fn i2c_controller_target<
-        P: Pins<I2C>,
-        T: IntoTimingRegister,
-        CT: IntoTimingRegister,
-    >(
+    fn i2c_target_only<P: Pins<I2C>, T: IntoI2cTiming>(
         self,
         _pins: P,
         timing: T,
-        target_config: TargetConfig<CT>,
+        config: TargetConfig,
         rec: I2C::Rec,
-        clocks: &CoreClocks,
-    ) -> I2c<I2C, SwitchRole> {
-        I2c::new(self, timing, Some(target_config), rec, clocks)
+    ) -> I2cTarget<I2C, AutoAck, SingleRole> {
+        I2cTarget::new(self, timing.into_i2c_timing(), config, rec)
     }
 
-    fn i2c_controller_target_unchecked<
-        T: IntoTimingRegister,
-        CT: IntoTimingRegister,
-    >(
+    fn i2c_target_only_unchecked<T: IntoI2cTiming>(
         self,
         timing: T,
-        target_config: TargetConfig<CT>,
+        target_config: TargetConfig,
         rec: I2C::Rec,
-        clocks: &CoreClocks,
+    ) -> I2cTarget<I2C, AutoAck, SingleRole> {
+        I2cTarget::new(self, timing.into_i2c_timing(), target_config, rec)
+    }
+
+    fn i2c_controller_target<P: Pins<I2C>, T: IntoI2cTiming>(
+        self,
+        _pins: P,
+        timing: T,
+        target_config: TargetConfig,
+        rec: I2C::Rec,
     ) -> I2c<I2C, SwitchRole> {
-        I2c::new(self, timing, Some(target_config), rec, clocks)
+        I2c::new(self, timing.into_i2c_timing(), Some(target_config), rec)
+    }
+
+    fn i2c_controller_target_unchecked<T: IntoI2cTiming>(
+        self,
+        timing: T,
+        target_config: TargetConfig,
+        rec: I2C::Rec,
+    ) -> I2c<I2C, SwitchRole> {
+        I2c::new(self, timing.into_i2c_timing(), Some(target_config), rec)
     }
 }
 
-fn configure_target_addresses<I2C: Instance, T: IntoTimingRegister>(
-    i2c: &I2C,
-    config: &TargetConfig<T>,
-) {
+fn configure_target_addresses<I2C: Instance>(i2c: &I2C, config: &TargetConfig) {
     i2c.oar1().write(|w| match config.own_address_mode {
         AddressMode::AddressMode7bit => {
             w.oa1().set(config.own_address << 1).oa1mode().bit7()
@@ -665,91 +636,8 @@ fn calc_timing_params(ker_ck: u32, target_freq: u32) -> (u8, u8, u8, u8, u8) {
     (presc_reg, scll, sclh, sdadel, scldel)
 }
 
-impl TimingRegister {
-    fn calc_register_value(&self) -> u32 {
-        ((self.presc as u32) << 28)
-            | ((self.scldel as u32) << 20)
-            | ((self.sdadel as u32) << 16)
-            | ((self.sclh as u32) << 8)
-            | (self.scll as u32)
-    }
-}
-
-impl fmt::Display for TimingRegister {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "TIMINGR: 0x{:08X} (PRESC: {}, SCLDEL: {}, SDADEL: {}, SCLH: {}, SCLL: {})",
-             self.calc_register_value(), self.presc, self.scldel, self.sdadel, self.sclh, self.scll
-        )
-    }
-}
-
-/// Trait for types that can be converted into a [`TimingRegister`], optionally using the
-/// I2C kernel clock frequency for frequency-based calculation.
-///
-/// Types that encode all timing information directly (raw register values, explicit timing
-/// parameters, or a pre-built [`TimingRegister`]) ignore `ker_ck`. Types that specify only
-/// a desired bus frequency (e.g. [`Hertz`]) use `ker_ck` to calculate the timing parameters.
-pub trait IntoTimingRegister: Copy {
-    fn into_timing(self, ker_ck: u32) -> TimingRegister;
-}
-
-/// Raw TIMINGR register value — parsed directly into timing fields.
-impl IntoTimingRegister for RawTimingr {
-    fn into_timing(self, _ker_ck: u32) -> TimingRegister {
-        let timingr = self.0;
-        TimingRegister {
-            presc: ((timingr >> 28) & 0x0F) as u8,
-            scldel: ((timingr >> 20) & 0x0F) as u8,
-            sdadel: ((timingr >> 16) & 0x0F) as u8,
-            sclh: ((timingr >> 8) & 0xFF) as u8,
-            scll: (timingr & 0xFF) as u8,
-        }
-    }
-}
-
-impl IntoTimingRegister for (u8, u8, u8, u8, u8) {
-    fn into_timing(self, _ker_ck: u32) -> TimingRegister {
-        let (presc, scldel, sdadel, sclh, scll) = self;
-        TimingRegister {
-            presc,
-            scldel,
-            sdadel,
-            sclh,
-            scll,
-        }
-    }
-}
-
-impl IntoTimingRegister for u32 {
-    fn into_timing(self, ker_ck: u32) -> TimingRegister {
-        let target_freq = self;
-        calc_timing_params(ker_ck, target_freq).into_timing(0)
-    }
-}
-
-impl IntoTimingRegister for TimingRegister {
-    fn into_timing(self, _ker_ck: u32) -> TimingRegister {
-        self
-    }
-}
-
-impl IntoTimingRegister for Hertz {
-    fn into_timing(self, ker_ck: u32) -> TimingRegister {
-        calc_timing_params(ker_ck, self.raw()).into_timing(0)
-    }
-}
-
 impl<I2C: Instance, R> I2c<I2C, R> {
     /// Create and initialise a new I2C peripheral.
-    ///
-    /// `timing` accepts anything that implements [`IntoTimingRegister`]:
-    /// - [`Hertz`] — calculates timing from the I2C kernel clock and the requested bus frequency.
-    /// - `u32` — a raw pre-computed TIMINGR register value.
-    /// - `(u8, u8, u8, u8, u8)` — explicit `(presc, scldel, sdadel, sclh, scll)` parameters.
-    /// - `(u32, u32)` — explicit `(ker_ck, target_freq)` tuple.
-    /// - [`TimingRegister`] — passed through unchanged.
     ///
     /// # Panics
     ///
@@ -757,17 +645,13 @@ impl<I2C: Instance, R> I2c<I2C, R> {
     /// is out of bounds. The acceptable range is [4, 8192].
     ///
     /// Panics if the bus frequency is too fast. The maximum is 1MHz.
-    pub fn new<Timing: IntoTimingRegister, CfgTiming: IntoTimingRegister>(
+    pub fn new(
         i2c: I2C,
-        timing: Timing,
-        config: Option<TargetConfig<CfgTiming>>,
+        timing: I2cTiming,
+        config: Option<TargetConfig>,
         rec: I2C::Rec,
-        clocks: &CoreClocks,
     ) -> Self {
         let _ = rec.enable().reset();
-
-        let i2c_ker_ck: u32 = I2C::clock(clocks).raw();
-        let timing_reg = timing.into_timing(i2c_ker_ck);
 
         // Clear PE bit in I2C_CR1
         i2c.cr1().modify(|_, w| w.pe().disabled());
@@ -775,15 +659,15 @@ impl<I2C: Instance, R> I2c<I2C, R> {
         // Configure timing
         i2c.timingr().write(|w| {
             w.presc()
-                .set(timing_reg.presc)
+                .set(timing.presc)
                 .scll()
-                .set(timing_reg.scll)
+                .set(timing.scll)
                 .sclh()
-                .set(timing_reg.sclh)
+                .set(timing.sclh)
                 .sdadel()
-                .set(timing_reg.sdadel)
+                .set(timing.sdadel)
                 .scldel()
-                .set(timing_reg.scldel)
+                .set(timing.scldel)
         });
 
         if let Some(ref config) = config {
@@ -807,28 +691,25 @@ impl<I2C: Instance, R> I2c<I2C, R> {
 
 /// Target implementation
 impl<I2C: Instance, A, R> I2cTarget<I2C, A, R> {
-    fn new<T: IntoTimingRegister>(
+    fn new(
         i2c: I2C,
-        config: TargetConfig<T>,
+        timing: I2cTiming,
+        config: TargetConfig,
         rec: I2C::Rec,
-        clocks: &CoreClocks,
     ) -> Self {
         let _ = rec.enable().reset();
 
         // Clear PE bit in I2C_CR1
         i2c.cr1().modify(|_, w| w.pe().disabled());
 
-        let i2c_ker_ck: u32 = I2C::clock(clocks).raw();
-
         // Configure timing parameters for target mode
-        let timing_reg = config.timing.into_timing(i2c_ker_ck);
         i2c.timingr().write(|w| {
             w.presc()
-                .set(timing_reg.presc)
+                .set(timing.presc)
                 .sdadel()
-                .set(timing_reg.sdadel)
+                .set(timing.sdadel)
                 .scldel()
-                .set(timing_reg.scldel)
+                .set(timing.scldel)
         });
 
         configure_target_addresses(&i2c, &config);
@@ -1674,10 +1555,7 @@ pub trait Targetable {
     /// Configure target after initialization: allows the target addresses to be
     /// dynamically configured. This will disable any target events previously
     /// enabled.
-    fn configure_target<T: IntoTimingRegister>(
-        &mut self,
-        config: TargetConfig<T>,
-    );
+    fn configure_target(&mut self, config: TargetConfig);
 }
 
 impl<I2C: Instance> Targetable for I2c<I2C, SwitchRole> {
@@ -1689,10 +1567,7 @@ impl<I2C: Instance> Targetable for I2c<I2C, SwitchRole> {
         self.inner.disable_target_event(event)
     }
 
-    fn configure_target<T: IntoTimingRegister>(
-        &mut self,
-        config: TargetConfig<T>,
-    ) {
+    fn configure_target(&mut self, config: TargetConfig) {
         configure_target_addresses(&self.i2c, &config)
     }
 }
@@ -1706,10 +1581,7 @@ impl<I2C: Instance, R> Targetable for I2cTarget<I2C, R> {
         self.inner.disable_target_event(event)
     }
 
-    fn configure_target<T: IntoTimingRegister>(
-        &mut self,
-        config: TargetConfig<T>,
-    ) {
+    fn configure_target(&mut self, config: TargetConfig) {
         configure_target_addresses(&self.i2c, &config)
     }
 }
@@ -1737,9 +1609,84 @@ impl<I2C> I2cTarget<I2C, SwitchRole> {
     }
 }
 
+/// Functions for calculating timing parameters for the I2C peripheral
+impl I2cTiming {
+    pub fn new(presc: u8, scldel: u8, sdadel: u8, sclh: u8, scll: u8) -> Self {
+        I2cTiming {
+            presc,
+            scldel,
+            sdadel,
+            sclh,
+            scll,
+        }
+    }
+
+    fn calc_register_value(&self) -> u32 {
+        ((self.presc as u32) << 28)
+            | ((self.scldel as u32) << 20)
+            | ((self.sdadel as u32) << 16)
+            | ((self.sclh as u32) << 8)
+            | (self.scll as u32)
+    }
+}
+
+impl fmt::Display for I2cTiming {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "TIMINGR: 0x{:08X} (PRESC: {}, SCLDEL: {}, SDADEL: {}, SCLH: {}, SCLL: {})",
+             self.calc_register_value(), self.presc, self.scldel, self.sdadel, self.sclh, self.scll
+        )
+    }
+}
+
+impl From<RawTimingr> for I2cTiming {
+    fn from(raw: RawTimingr) -> Self {
+        I2cTiming {
+            presc: ((raw.0 >> 28) & 0x0F) as u8,
+            scldel: ((raw.0 >> 20) & 0x0F) as u8,
+            sdadel: ((raw.0 >> 16) & 0x0F) as u8,
+            sclh: ((raw.0 >> 8) & 0xFF) as u8,
+            scll: (raw.0 & 0xFF) as u8,
+        }
+    }
+}
+
+/// A type that can be converted into [`I2cTiming`].
+///
+/// Implemented for:
+/// - [`I2cTiming`] — used as-is
+/// - [`RawTimingr`] — decoded from a raw TIMINGR register value (e.g. from STM32CubeMX)
+/// - `(Hertz, Hertz)` — `(ker_ck, bus_freq)` tuple; computes timing at runtime
+pub trait IntoI2cTiming {
+    fn into_i2c_timing(self) -> I2cTiming;
+}
+
+impl IntoI2cTiming for I2cTiming {
+    fn into_i2c_timing(self) -> I2cTiming {
+        self
+    }
+}
+
+impl IntoI2cTiming for RawTimingr {
+    fn into_i2c_timing(self) -> I2cTiming {
+        self.into()
+    }
+}
+
+impl IntoI2cTiming for (Hertz, Hertz) {
+    fn into_i2c_timing(self) -> I2cTiming {
+        let (ker_ck, bus_freq) = self;
+        let (presc, scll, sclh, sdadel, scldel) =
+            calc_timing_params(ker_ck.raw(), bus_freq.raw());
+        I2cTiming { presc, scldel, sdadel, sclh, scll }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::i2c::{calc_timing_params, IntoTimingRegister, RawTimingr};
+    use crate::i2c::{I2cTiming, RawTimingr, calc_timing_params};
+    use crate::time::Hertz;
 
     /// Runs a timing testcase over PCLK and I2C clock ranges
     fn i2c_timing_testcase<F>(f: F)
@@ -1959,17 +1906,20 @@ mod tests {
         let sdadel = 0;
         let sclh = 16;
         let scll = 48;
-        let t1 = RawTimingr(timingr).into_timing(0);
+        let raw_timing = RawTimingr(timingr);
+        let t1: I2cTiming = raw_timing.into();
         assert_eq!(t1.presc, presc);
         assert_eq!(t1.scldel, scldel);
         assert_eq!(t1.sdadel, sdadel);
         assert_eq!(t1.sclh, sclh);
         assert_eq!(t1.scll, scll);
 
-        let t2 = (presc, scldel, sdadel, sclh, scll).into_timing(0);
+        let t2 = I2cTiming::new(presc, scldel, sdadel, sclh, scll);
         assert_eq!(timingr, t2.calc_register_value());
 
-        let t3 = 200_000u32.into_timing(250_000_000);
+        use crate::i2c::IntoI2cTiming;
+        // let t3 = 200_000u32.into_timing(250_000_000);
+        let t3 = (Hertz::from_raw(250_000_000), Hertz::from_raw(200_000)).into_i2c_timing();
         assert_eq!(t3.calc_register_value(), 0xd39c050f);
     }
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -147,9 +147,9 @@
 //! - [I2C Target simple example](https://github.com/stm32-rs/stm32h5xx-hal/blob/master/examples/i2c_target.rs)
 //! - [I2C Target with manual ACK control](https://github.com/stm32-rs/stm32h5xx-hal/blob/master/examples/i2c_target_manual_ack.rs)
 
-use core::iter;
 use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut};
+use core::{fmt, iter};
 
 use crate::rcc::{CoreClocks, ResetEnable};
 
@@ -318,6 +318,28 @@ pub struct ManualAck;
 /// Marker struct for I2cTarget implementation to indicate that it automatically handles all ACK'ing
 pub struct AutoAck;
 
+/// A raw pre-computed TIMINGR register value.
+///
+/// Wraps a `u32` to distinguish it from a bus frequency when passing to
+/// [`I2c::new`] or the [`I2cExt`] constructors. Obtain a value from STM32CubeMX
+/// or AN4235 and wrap it here to bypass runtime timing calculation.
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct RawTimingr(pub u32);
+
+/// Represents the TIMINGR register and its associated timing parameters for an I2C peripheral.
+/// This can be instantiated from a constant calculated elsewhere (CubeMX or AN4235)
+/// or calculated at runtime from the peripheral clock and target bus frequency.
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct TimingRegister {
+    presc: u8,
+    scldel: u8,
+    sdadel: u8,
+    sclh: u8,
+    scll: u8,
+}
+
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct I2c<I2C, R = SingleRole> {
@@ -367,48 +389,52 @@ impl<I2C> Inner<I2C> {
 
 pub trait I2cExt<I2C: Instance>: Sized {
     /// Create a I2c instance that is capable of Controller operation only
-    fn i2c<P: Pins<I2C>>(
+    fn i2c<P: Pins<I2C>, T: IntoTimingRegister>(
         self,
         _pins: P,
-        frequency: Hertz,
+        timing: T,
         rec: I2C::Rec,
         clocks: &CoreClocks,
     ) -> I2c<I2C, SingleRole>;
 
     /// Create a I2c instance that is capable of Controller operation only.
     /// This will not check that the pins are properly configured.
-    fn i2c_unchecked(
+    fn i2c_unchecked<T: IntoTimingRegister>(
         self,
-        frequency: Hertz,
+        timing: T,
         rec: I2C::Rec,
         clocks: &CoreClocks,
     ) -> I2c<I2C, SingleRole>;
 
     /// Create an I2cTarget instance capable of Target operation only
-    fn i2c_target_only<P: Pins<I2C>>(
+    fn i2c_target_only<P: Pins<I2C>, T: IntoTimingRegister>(
         self,
         _pins: P,
-        target_config: TargetConfig,
+        target_config: TargetConfig<T>,
         rec: I2C::Rec,
         clocks: &CoreClocks,
     ) -> I2cTarget<I2C, AutoAck, SingleRole>;
 
     /// Create an I2cTarget instance capable of Target operation only.
     /// This will not check that the pins are properly configured.
-    fn i2c_target_only_unchecked<P: Pins<I2C>>(
+    fn i2c_target_only_unchecked<T: IntoTimingRegister>(
         self,
-        target_config: TargetConfig,
+        target_config: TargetConfig<T>,
         rec: I2C::Rec,
         clocks: &CoreClocks,
     ) -> I2cTarget<I2C, AutoAck, SingleRole>;
 
     /// Create an I2c instance that can switch roles to a I2cTarget to perform
     /// Target operations
-    fn i2c_controller_target<P: Pins<I2C>>(
+    fn i2c_controller_target<
+        P: Pins<I2C>,
+        T: IntoTimingRegister,
+        CT: IntoTimingRegister,
+    >(
         self,
         _pins: P,
-        frequency: Hertz,
-        target_config: TargetConfig,
+        timing: T,
+        target_config: TargetConfig<CT>,
         rec: I2C::Rec,
         clocks: &CoreClocks,
     ) -> I2c<I2C, SwitchRole>;
@@ -416,73 +442,107 @@ pub trait I2cExt<I2C: Instance>: Sized {
     /// Create an I2c instance that can switch roles to a I2cTarget to perform
     /// Target operations.
     /// This will not check that the pins are properly configured.
-    fn i2c_controller_target_unchecked(
+    fn i2c_controller_target_unchecked<
+        T: IntoTimingRegister,
+        CT: IntoTimingRegister,
+    >(
         self,
-        frequency: Hertz,
-        target_config: TargetConfig,
+        timing: T,
+        target_config: TargetConfig<CT>,
         rec: I2C::Rec,
         clocks: &CoreClocks,
     ) -> I2c<I2C, SwitchRole>;
 }
 
 impl<I2C: Instance> I2cExt<I2C> for I2C {
-    fn i2c<P: Pins<I2C>>(
+    fn i2c<P: Pins<I2C>, T: IntoTimingRegister>(
         self,
         _pins: P,
-        frequency: Hertz,
+        timing: T,
         rec: I2C::Rec,
         clocks: &CoreClocks,
     ) -> I2c<I2C, SingleRole> {
-        I2c::new(self, frequency, None::<TargetConfig>, rec, clocks)
+        I2c::new(self, timing, None::<TargetConfig<Hertz>>, rec, clocks)
     }
 
-    fn i2c_unchecked(
+    fn i2c_unchecked<T: IntoTimingRegister>(
         self,
-        frequency: Hertz,
+        timing: T,
         rec: I2C::Rec,
         clocks: &CoreClocks,
     ) -> I2c<I2C, SingleRole> {
-        I2c::new(self, frequency, None::<TargetConfig>, rec, clocks)
+        I2c::new(self, timing, None::<TargetConfig<Hertz>>, rec, clocks)
     }
 
-    fn i2c_target_only<P: Pins<I2C>>(
+    fn i2c_target_only<P: Pins<I2C>, T: IntoTimingRegister>(
         self,
         _pins: P,
-        config: TargetConfig,
+        config: TargetConfig<T>,
         rec: I2C::Rec,
         clocks: &CoreClocks,
     ) -> I2cTarget<I2C, AutoAck, SingleRole> {
         I2cTarget::new(self, config, rec, clocks)
     }
 
-    fn i2c_target_only_unchecked<P: Pins<I2C>>(
+    fn i2c_target_only_unchecked<T: IntoTimingRegister>(
         self,
-        target_config: TargetConfig,
+        target_config: TargetConfig<T>,
         rec: I2C::Rec,
         clocks: &CoreClocks,
     ) -> I2cTarget<I2C, AutoAck, SingleRole> {
         I2cTarget::new(self, target_config, rec, clocks)
     }
 
-    fn i2c_controller_target<P: Pins<I2C>>(
+    fn i2c_controller_target<
+        P: Pins<I2C>,
+        T: IntoTimingRegister,
+        CT: IntoTimingRegister,
+    >(
         self,
         _pins: P,
-        frequency: Hertz,
-        target_config: TargetConfig,
+        timing: T,
+        target_config: TargetConfig<CT>,
         rec: I2C::Rec,
         clocks: &CoreClocks,
     ) -> I2c<I2C, SwitchRole> {
-        I2c::new(self, frequency, Some(target_config), rec, clocks)
+        I2c::new(self, timing, Some(target_config), rec, clocks)
     }
 
-    fn i2c_controller_target_unchecked(
+    fn i2c_controller_target_unchecked<
+        T: IntoTimingRegister,
+        CT: IntoTimingRegister,
+    >(
         self,
-        frequency: Hertz,
-        target_config: TargetConfig,
+        timing: T,
+        target_config: TargetConfig<CT>,
         rec: I2C::Rec,
         clocks: &CoreClocks,
     ) -> I2c<I2C, SwitchRole> {
-        I2c::new(self, frequency, Some(target_config), rec, clocks)
+        I2c::new(self, timing, Some(target_config), rec, clocks)
+    }
+}
+
+fn configure_target_addresses<I2C: Instance, T: IntoTimingRegister>(
+    i2c: &I2C,
+    config: &TargetConfig<T>,
+) {
+    i2c.oar1().write(|w| match config.own_address_mode {
+        AddressMode::AddressMode7bit => {
+            w.oa1().set(config.own_address << 1).oa1mode().bit7()
+        }
+        AddressMode::AddressMode10bit => {
+            w.oa1().set(config.own_address).oa1mode().bit10()
+        }
+    });
+
+    if let Some(secondary_address) = config.secondary_address {
+        i2c.oar2().write(|w| {
+            w.oa2().set(secondary_address);
+            if let Some(mask) = config.secondary_address_mask_bits {
+                w.oa2msk().set(mask + 1); // The address is shifted up by one, so increment the mask bits too
+            }
+            w
+        });
     }
 }
 
@@ -605,74 +665,128 @@ fn calc_timing_params(ker_ck: u32, target_freq: u32) -> (u8, u8, u8, u8, u8) {
     (presc_reg, scll, sclh, sdadel, scldel)
 }
 
-fn configure_target_addresses<I2C: Instance>(i2c: &I2C, config: TargetConfig) {
-    i2c.oar1().write(|w| match config.own_address_mode {
-        AddressMode::AddressMode7bit => {
-            w.oa1().set(config.own_address << 1).oa1mode().bit7()
-        }
-        AddressMode::AddressMode10bit => {
-            w.oa1().set(config.own_address).oa1mode().bit10()
-        }
-    });
+impl TimingRegister {
+    fn calc_register_value(&self) -> u32 {
+        ((self.presc as u32) << 28)
+            | ((self.scldel as u32) << 20)
+            | ((self.sdadel as u32) << 16)
+            | ((self.sclh as u32) << 8)
+            | (self.scll as u32)
+    }
+}
 
-    if let Some(secondary_address) = config.secondary_address {
-        i2c.oar2().write(|w| {
-            w.oa2().set(secondary_address);
-            if let Some(mask) = config.secondary_address_mask_bits {
-                w.oa2msk().set(mask + 1); // The address is shifted up by one, so increment the mask bits too
-            }
-            w
-        });
+impl fmt::Display for TimingRegister {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "TIMINGR: 0x{:08X} (PRESC: {}, SCLDEL: {}, SDADEL: {}, SCLH: {}, SCLL: {})",
+             self.calc_register_value(), self.presc, self.scldel, self.sdadel, self.sclh, self.scll
+        )
+    }
+}
+
+/// Trait for types that can be converted into a [`TimingRegister`], optionally using the
+/// I2C kernel clock frequency for frequency-based calculation.
+///
+/// Types that encode all timing information directly (raw register values, explicit timing
+/// parameters, or a pre-built [`TimingRegister`]) ignore `ker_ck`. Types that specify only
+/// a desired bus frequency (e.g. [`Hertz`]) use `ker_ck` to calculate the timing parameters.
+pub trait IntoTimingRegister: Copy {
+    fn into_timing(self, ker_ck: u32) -> TimingRegister;
+}
+
+/// Raw TIMINGR register value — parsed directly into timing fields.
+impl IntoTimingRegister for RawTimingr {
+    fn into_timing(self, _ker_ck: u32) -> TimingRegister {
+        let timingr = self.0;
+        TimingRegister {
+            presc: ((timingr >> 28) & 0x0F) as u8,
+            scldel: ((timingr >> 20) & 0x0F) as u8,
+            sdadel: ((timingr >> 16) & 0x0F) as u8,
+            sclh: ((timingr >> 8) & 0xFF) as u8,
+            scll: (timingr & 0xFF) as u8,
+        }
+    }
+}
+
+impl IntoTimingRegister for (u8, u8, u8, u8, u8) {
+    fn into_timing(self, _ker_ck: u32) -> TimingRegister {
+        let (presc, scldel, sdadel, sclh, scll) = self;
+        TimingRegister {
+            presc,
+            scldel,
+            sdadel,
+            sclh,
+            scll,
+        }
+    }
+}
+
+impl IntoTimingRegister for u32 {
+    fn into_timing(self, ker_ck: u32) -> TimingRegister {
+        let target_freq = self;
+        calc_timing_params(ker_ck, target_freq).into_timing(0)
+    }
+}
+
+impl IntoTimingRegister for TimingRegister {
+    fn into_timing(self, _ker_ck: u32) -> TimingRegister {
+        self
+    }
+}
+
+impl IntoTimingRegister for Hertz {
+    fn into_timing(self, ker_ck: u32) -> TimingRegister {
+        calc_timing_params(ker_ck, self.raw()).into_timing(0)
     }
 }
 
 impl<I2C: Instance, R> I2c<I2C, R> {
     /// Create and initialise a new I2C peripheral.
     ///
-    /// The frequency of the I2C bus clock is specified by `frequency`.
+    /// `timing` accepts anything that implements [`IntoTimingRegister`]:
+    /// - [`Hertz`] — calculates timing from the I2C kernel clock and the requested bus frequency.
+    /// - `u32` — a raw pre-computed TIMINGR register value.
+    /// - `(u8, u8, u8, u8, u8)` — explicit `(presc, scldel, sdadel, sclh, scll)` parameters.
+    /// - `(u32, u32)` — explicit `(ker_ck, target_freq)` tuple.
+    /// - [`TimingRegister`] — passed through unchanged.
     ///
     /// # Panics
     ///
-    /// Panics if the ratio between `frequency` and the i2c_ker_ck
+    /// Panics if the ratio between the bus frequency and the i2c_ker_ck
     /// is out of bounds. The acceptable range is [4, 8192].
     ///
-    /// Panics if the `frequency` is too fast. The maximum is 1MHz.
-    pub fn new(
+    /// Panics if the bus frequency is too fast. The maximum is 1MHz.
+    pub fn new<Timing: IntoTimingRegister, CfgTiming: IntoTimingRegister>(
         i2c: I2C,
-        frequency: Hertz,
-        config: Option<TargetConfig>,
+        timing: Timing,
+        config: Option<TargetConfig<CfgTiming>>,
         rec: I2C::Rec,
         clocks: &CoreClocks,
     ) -> Self {
         let _ = rec.enable().reset();
 
-        let freq: u32 = frequency.raw();
-
-        // Maximum f_SCL for Fast-mode Plus (Fm+)
-        assert!(freq <= 1_000_000);
-
         let i2c_ker_ck: u32 = I2C::clock(clocks).raw();
+        let timing_reg = timing.into_timing(i2c_ker_ck);
 
         // Clear PE bit in I2C_CR1
         i2c.cr1().modify(|_, w| w.pe().disabled());
 
         // Configure timing
-        let (presc_reg, scll, sclh, sdadel, scldel) =
-            calc_timing_params(i2c_ker_ck, freq);
         i2c.timingr().write(|w| {
             w.presc()
-                .set(presc_reg)
+                .set(timing_reg.presc)
                 .scll()
-                .set(scll)
+                .set(timing_reg.scll)
                 .sclh()
-                .set(sclh)
+                .set(timing_reg.sclh)
                 .sdadel()
-                .set(sdadel)
+                .set(timing_reg.sdadel)
                 .scldel()
-                .set(scldel)
+                .set(timing_reg.scldel)
         });
 
-        if let Some(config) = config {
+        if let Some(ref config) = config {
             configure_target_addresses(&i2c, config);
         }
 
@@ -693,9 +807,9 @@ impl<I2C: Instance, R> I2c<I2C, R> {
 
 /// Target implementation
 impl<I2C: Instance, A, R> I2cTarget<I2C, A, R> {
-    fn new(
+    fn new<T: IntoTimingRegister>(
         i2c: I2C,
-        config: TargetConfig,
+        config: TargetConfig<T>,
         rec: I2C::Rec,
         clocks: &CoreClocks,
     ) -> Self {
@@ -707,18 +821,17 @@ impl<I2C: Instance, A, R> I2cTarget<I2C, A, R> {
         let i2c_ker_ck: u32 = I2C::clock(clocks).raw();
 
         // Configure timing parameters for target mode
-        let (presc_reg, _, _, sdadel, scldel) =
-            calc_timing_params(i2c_ker_ck, config.bus_frequency_hz);
+        let timing_reg = config.timing.into_timing(i2c_ker_ck);
         i2c.timingr().write(|w| {
             w.presc()
-                .set(presc_reg)
+                .set(timing_reg.presc)
                 .sdadel()
-                .set(sdadel)
+                .set(timing_reg.sdadel)
                 .scldel()
-                .set(scldel)
+                .set(timing_reg.scldel)
         });
 
-        configure_target_addresses(&i2c, config);
+        configure_target_addresses(&i2c, &config);
 
         // Enable the peripheral and Analog Noise Filter
         i2c.cr1().modify(|_, w| w.pe().enabled().anfoff().enabled());
@@ -884,8 +997,8 @@ impl<I2C: Instance> Inner<I2C> {
 /// [Read](I2c#impl-Read) and [Write](I2c#impl-Write)
 /// implementations.
 ///
-/// If a previous transcation is still in progress, then these
-/// methods will block until that transcation is complete. A
+/// If a previous transaction is still in progress, then these
+/// methods will block until that transaction is complete. A
 /// previous transaction can still be "in progress" up to 50% of a
 /// bus cycle after a ACK/NACK event. Otherwise these methods return
 /// immediately.
@@ -1561,7 +1674,10 @@ pub trait Targetable {
     /// Configure target after initialization: allows the target addresses to be
     /// dynamically configured. This will disable any target events previously
     /// enabled.
-    fn configure_target(&mut self, config: TargetConfig);
+    fn configure_target<T: IntoTimingRegister>(
+        &mut self,
+        config: TargetConfig<T>,
+    );
 }
 
 impl<I2C: Instance> Targetable for I2c<I2C, SwitchRole> {
@@ -1573,8 +1689,11 @@ impl<I2C: Instance> Targetable for I2c<I2C, SwitchRole> {
         self.inner.disable_target_event(event)
     }
 
-    fn configure_target(&mut self, config: TargetConfig) {
-        configure_target_addresses(&self.i2c, config)
+    fn configure_target<T: IntoTimingRegister>(
+        &mut self,
+        config: TargetConfig<T>,
+    ) {
+        configure_target_addresses(&self.i2c, &config)
     }
 }
 
@@ -1587,8 +1706,11 @@ impl<I2C: Instance, R> Targetable for I2cTarget<I2C, R> {
         self.inner.disable_target_event(event)
     }
 
-    fn configure_target(&mut self, config: TargetConfig) {
-        configure_target_addresses(&self.i2c, config)
+    fn configure_target<T: IntoTimingRegister>(
+        &mut self,
+        config: TargetConfig<T>,
+    ) {
+        configure_target_addresses(&self.i2c, &config)
     }
 }
 
@@ -1617,7 +1739,7 @@ impl<I2C> I2cTarget<I2C, SwitchRole> {
 
 #[cfg(test)]
 mod tests {
-    use crate::i2c::calc_timing_params;
+    use crate::i2c::{calc_timing_params, IntoTimingRegister, RawTimingr};
 
     /// Runs a timing testcase over PCLK and I2C clock ranges
     fn i2c_timing_testcase<F>(f: F)
@@ -1827,5 +1949,27 @@ mod tests {
             assert!(scldel <= 15);
             assert!(t_scldel >= t_scldel_minimum);
         });
+    }
+
+    #[test]
+    fn test_i2c_timing_constructor() {
+        let timingr: u32 = 0x20901030;
+        let presc = 2;
+        let scldel = 9;
+        let sdadel = 0;
+        let sclh = 16;
+        let scll = 48;
+        let t1 = RawTimingr(timingr).into_timing(0);
+        assert_eq!(t1.presc, presc);
+        assert_eq!(t1.scldel, scldel);
+        assert_eq!(t1.sdadel, sdadel);
+        assert_eq!(t1.sclh, sclh);
+        assert_eq!(t1.scll, scll);
+
+        let t2 = (presc, scldel, sdadel, sclh, scll).into_timing(0);
+        assert_eq!(timingr, t2.calc_register_value());
+
+        let t3 = 200_000u32.into_timing(250_000_000);
+        assert_eq!(t3.calc_register_value(), 0xd39c050f);
     }
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -64,6 +64,7 @@
 //!     bus_freq,
 //!     TargetConfig::new(own_addr),
 //!     ccdr.peripheral.I2C1,
+//!     &ccdr.clocks,
 //! );
 //! ```
 //!
@@ -129,6 +130,7 @@
 //!     bus_freq,
 //!     TargetConfig::new(own_addr),
 //!     ccdr.peripheral.I2C1,
+//!     &ccdr.clocks,
 //! );
 //! ```
 //!
@@ -320,22 +322,6 @@ pub struct ManualAck;
 /// Marker struct for I2cTarget implementation to indicate that it automatically handles all ACK'ing
 pub struct AutoAck;
 
-/// A raw u32 representation of the TIMINGR register, which can be converted into an I2cTiming struct.
-pub struct RawTimingr(pub u32);
-
-/// Represents the TIMINGR register and its associated timing parameters for an I2C peripheral.
-/// This can be instantiated from a constant calculated elsewhere (CubeMX or AN4235)
-/// or calculated at runtime from the peripheral clock and target bus frequency.
-#[derive(Debug, Copy, Clone)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct I2cTiming {
-    presc: u8,
-    scldel: u8,
-    sdadel: u8,
-    sclh: u8,
-    scll: u8,
-}
-
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct I2c<I2C, R = SingleRole> {
@@ -390,6 +376,7 @@ pub trait I2cExt<I2C: Instance>: Sized {
         _pins: P,
         timing: T,
         rec: I2C::Rec,
+        clocks: &CoreClocks,
     ) -> I2c<I2C, SingleRole>;
 
     /// Create a I2c instance that is capable of Controller operation only.
@@ -398,6 +385,7 @@ pub trait I2cExt<I2C: Instance>: Sized {
         self,
         timing: T,
         rec: I2C::Rec,
+        clocks: &CoreClocks,
     ) -> I2c<I2C, SingleRole>;
 
     /// Create an I2cTarget instance capable of Target operation only
@@ -407,6 +395,7 @@ pub trait I2cExt<I2C: Instance>: Sized {
         timing: T,
         target_config: TargetConfig,
         rec: I2C::Rec,
+        clocks: &CoreClocks,
     ) -> I2cTarget<I2C, AutoAck, SingleRole>;
 
     /// Create an I2cTarget instance capable of Target operation only.
@@ -416,6 +405,7 @@ pub trait I2cExt<I2C: Instance>: Sized {
         timing: T,
         target_config: TargetConfig,
         rec: I2C::Rec,
+        clocks: &CoreClocks,
     ) -> I2cTarget<I2C, AutoAck, SingleRole>;
 
     /// Create an I2c instance that can switch roles to a I2cTarget to perform
@@ -426,6 +416,7 @@ pub trait I2cExt<I2C: Instance>: Sized {
         timing: T,
         target_config: TargetConfig,
         rec: I2C::Rec,
+        clocks: &CoreClocks,
     ) -> I2c<I2C, SwitchRole>;
 
     /// Create an I2c instance that can switch roles to a I2cTarget to perform
@@ -436,6 +427,7 @@ pub trait I2cExt<I2C: Instance>: Sized {
         timing: T,
         target_config: TargetConfig,
         rec: I2C::Rec,
+        clocks: &CoreClocks,
     ) -> I2c<I2C, SwitchRole>;
 }
 
@@ -445,16 +437,28 @@ impl<I2C: Instance> I2cExt<I2C> for I2C {
         _pins: P,
         timing: T,
         rec: I2C::Rec,
+        clocks: &CoreClocks,
     ) -> I2c<I2C, SingleRole> {
-        I2c::new(self, timing.into_i2c_timing(), None::<TargetConfig>, rec)
+        I2c::new(
+            self,
+            timing.into_i2c_timing(I2C::clock(clocks).raw()),
+            None::<TargetConfig>,
+            rec,
+        )
     }
 
     fn i2c_unchecked<T: IntoI2cTiming>(
         self,
         timing: T,
         rec: I2C::Rec,
+        clocks: &CoreClocks,
     ) -> I2c<I2C, SingleRole> {
-        I2c::new(self, timing.into_i2c_timing(), None::<TargetConfig>, rec)
+        I2c::new(
+            self,
+            timing.into_i2c_timing(I2C::clock(clocks).raw()),
+            None::<TargetConfig>,
+            rec,
+        )
     }
 
     fn i2c_target_only<P: Pins<I2C>, T: IntoI2cTiming>(
@@ -463,8 +467,14 @@ impl<I2C: Instance> I2cExt<I2C> for I2C {
         timing: T,
         config: TargetConfig,
         rec: I2C::Rec,
+        clocks: &CoreClocks,
     ) -> I2cTarget<I2C, AutoAck, SingleRole> {
-        I2cTarget::new(self, timing.into_i2c_timing(), config, rec)
+        I2cTarget::new(
+            self,
+            timing.into_i2c_timing(I2C::clock(clocks).raw()),
+            config,
+            rec,
+        )
     }
 
     fn i2c_target_only_unchecked<T: IntoI2cTiming>(
@@ -472,8 +482,14 @@ impl<I2C: Instance> I2cExt<I2C> for I2C {
         timing: T,
         target_config: TargetConfig,
         rec: I2C::Rec,
+        clocks: &CoreClocks,
     ) -> I2cTarget<I2C, AutoAck, SingleRole> {
-        I2cTarget::new(self, timing.into_i2c_timing(), target_config, rec)
+        I2cTarget::new(
+            self,
+            timing.into_i2c_timing(I2C::clock(clocks).raw()),
+            target_config,
+            rec,
+        )
     }
 
     fn i2c_controller_target<P: Pins<I2C>, T: IntoI2cTiming>(
@@ -482,8 +498,14 @@ impl<I2C: Instance> I2cExt<I2C> for I2C {
         timing: T,
         target_config: TargetConfig,
         rec: I2C::Rec,
+        clocks: &CoreClocks,
     ) -> I2c<I2C, SwitchRole> {
-        I2c::new(self, timing.into_i2c_timing(), Some(target_config), rec)
+        I2c::new(
+            self,
+            timing.into_i2c_timing(I2C::clock(clocks).raw()),
+            Some(target_config),
+            rec,
+        )
     }
 
     fn i2c_controller_target_unchecked<T: IntoI2cTiming>(
@@ -491,29 +513,14 @@ impl<I2C: Instance> I2cExt<I2C> for I2C {
         timing: T,
         target_config: TargetConfig,
         rec: I2C::Rec,
+        clocks: &CoreClocks,
     ) -> I2c<I2C, SwitchRole> {
-        I2c::new(self, timing.into_i2c_timing(), Some(target_config), rec)
-    }
-}
-
-fn configure_target_addresses<I2C: Instance>(i2c: &I2C, config: &TargetConfig) {
-    i2c.oar1().write(|w| match config.own_address_mode {
-        AddressMode::AddressMode7bit => {
-            w.oa1().set(config.own_address << 1).oa1mode().bit7()
-        }
-        AddressMode::AddressMode10bit => {
-            w.oa1().set(config.own_address).oa1mode().bit10()
-        }
-    });
-
-    if let Some(secondary_address) = config.secondary_address {
-        i2c.oar2().write(|w| {
-            w.oa2().set(secondary_address);
-            if let Some(mask) = config.secondary_address_mask_bits {
-                w.oa2msk().set(mask + 1); // The address is shifted up by one, so increment the mask bits too
-            }
-            w
-        });
+        I2c::new(
+            self,
+            timing.into_i2c_timing(I2C::clock(clocks).raw()),
+            Some(target_config),
+            rec,
+        )
     }
 }
 
@@ -636,6 +643,27 @@ fn calc_timing_params(ker_ck: u32, target_freq: u32) -> (u8, u8, u8, u8, u8) {
     (presc_reg, scll, sclh, sdadel, scldel)
 }
 
+fn configure_target_addresses<I2C: Instance>(i2c: &I2C, config: TargetConfig) {
+    i2c.oar1().write(|w| match config.own_address_mode {
+        AddressMode::AddressMode7bit => {
+            w.oa1().set(config.own_address << 1).oa1mode().bit7()
+        }
+        AddressMode::AddressMode10bit => {
+            w.oa1().set(config.own_address).oa1mode().bit10()
+        }
+    });
+
+    if let Some(secondary_address) = config.secondary_address {
+        i2c.oar2().write(|w| {
+            w.oa2().set(secondary_address);
+            if let Some(mask) = config.secondary_address_mask_bits {
+                w.oa2msk().set(mask + 1); // The address is shifted up by one, so increment the mask bits too
+            }
+            w
+        });
+    }
+}
+
 impl<I2C: Instance, R> I2c<I2C, R> {
     /// Create and initialise a new I2C peripheral.
     ///
@@ -670,7 +698,7 @@ impl<I2C: Instance, R> I2c<I2C, R> {
                 .set(timing.scldel)
         });
 
-        if let Some(ref config) = config {
+        if let Some(config) = config {
             configure_target_addresses(&i2c, config);
         }
 
@@ -712,7 +740,7 @@ impl<I2C: Instance, A, R> I2cTarget<I2C, A, R> {
                 .set(timing.scldel)
         });
 
-        configure_target_addresses(&i2c, &config);
+        configure_target_addresses(&i2c, config);
 
         // Enable the peripheral and Analog Noise Filter
         i2c.cr1().modify(|_, w| w.pe().enabled().anfoff().enabled());
@@ -1568,7 +1596,7 @@ impl<I2C: Instance> Targetable for I2c<I2C, SwitchRole> {
     }
 
     fn configure_target(&mut self, config: TargetConfig) {
-        configure_target_addresses(&self.i2c, &config)
+        configure_target_addresses(&self.i2c, config)
     }
 }
 
@@ -1582,7 +1610,7 @@ impl<I2C: Instance, R> Targetable for I2cTarget<I2C, R> {
     }
 
     fn configure_target(&mut self, config: TargetConfig) {
-        configure_target_addresses(&self.i2c, &config)
+        configure_target_addresses(&self.i2c, config)
     }
 }
 
@@ -1609,7 +1637,22 @@ impl<I2C> I2cTarget<I2C, SwitchRole> {
     }
 }
 
-/// Functions for calculating timing parameters for the I2C peripheral
+/// A raw u32 representation of the TIMINGR register, which can be converted into an I2cTiming struct.
+pub struct RawTimingr(pub u32);
+
+/// Represents the TIMINGR register and its associated timing parameters for an I2C peripheral.
+/// This can be instantiated from a constant calculated elsewhere (CubeMX or AN4235)
+/// or calculated at runtime from the peripheral clock and target bus frequency.
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct I2cTiming {
+    presc: u8,
+    scldel: u8,
+    sdadel: u8,
+    sclh: u8,
+    scll: u8,
+}
+
 impl I2cTiming {
     pub fn new(presc: u8, scldel: u8, sdadel: u8, sclh: u8, scll: u8) -> Self {
         I2cTiming {
@@ -1620,35 +1663,33 @@ impl I2cTiming {
             scll,
         }
     }
-
-    fn calc_register_value(&self) -> u32 {
-        ((self.presc as u32) << 28)
-            | ((self.scldel as u32) << 20)
-            | ((self.sdadel as u32) << 16)
-            | ((self.sclh as u32) << 8)
-            | (self.scll as u32)
-    }
 }
 
 impl fmt::Display for I2cTiming {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let timingr = RawTimingr::from(*self);
         write!(
             f,
             "TIMINGR: 0x{:08X} (PRESC: {}, SCLDEL: {}, SDADEL: {}, SCLH: {}, SCLL: {})",
-             self.calc_register_value(), self.presc, self.scldel, self.sdadel, self.sclh, self.scll
+             timingr.0, self.presc, self.scldel, self.sdadel, self.sclh, self.scll
         )
     }
 }
 
 impl From<RawTimingr> for I2cTiming {
     fn from(raw: RawTimingr) -> Self {
-        I2cTiming {
-            presc: ((raw.0 >> 28) & 0x0F) as u8,
-            scldel: ((raw.0 >> 20) & 0x0F) as u8,
-            sdadel: ((raw.0 >> 16) & 0x0F) as u8,
-            sclh: ((raw.0 >> 8) & 0xFF) as u8,
-            scll: (raw.0 & 0xFF) as u8,
-        }
+        raw.into_i2c_timing(0)
+    }
+}
+
+impl From<I2cTiming> for RawTimingr {
+    fn from(timing: I2cTiming) -> Self {
+        let timingr = ((timing.presc as u32) << 28)
+            | ((timing.scldel as u32) << 20)
+            | ((timing.sdadel as u32) << 16)
+            | ((timing.sclh as u32) << 8)
+            | (timing.scll as u32);
+        RawTimingr(timingr)
     }
 }
 
@@ -1657,35 +1698,48 @@ impl From<RawTimingr> for I2cTiming {
 /// Implemented for:
 /// - [`I2cTiming`] — used as-is
 /// - [`RawTimingr`] — decoded from a raw TIMINGR register value (e.g. from STM32CubeMX)
-/// - `(Hertz, Hertz)` — `(ker_ck, bus_freq)` tuple; computes timing at runtime
+/// - [`Hertz`] — computes timing from the I2C kernel clock and the requested bus frequency
 pub trait IntoI2cTiming {
-    fn into_i2c_timing(self) -> I2cTiming;
+    fn into_i2c_timing(self, ker_ck: u32) -> I2cTiming;
 }
 
 impl IntoI2cTiming for I2cTiming {
-    fn into_i2c_timing(self) -> I2cTiming {
+    fn into_i2c_timing(self, _ker_ck: u32) -> I2cTiming {
         self
     }
 }
 
 impl IntoI2cTiming for RawTimingr {
-    fn into_i2c_timing(self) -> I2cTiming {
-        self.into()
+    fn into_i2c_timing(self, _ker_ck: u32) -> I2cTiming {
+        I2cTiming {
+            presc: ((self.0 >> 28) & 0x0F) as u8,
+            scldel: ((self.0 >> 20) & 0x0F) as u8,
+            sdadel: ((self.0 >> 16) & 0x0F) as u8,
+            sclh: ((self.0 >> 8) & 0xFF) as u8,
+            scll: (self.0 & 0xFF) as u8,
+        }
     }
 }
 
-impl IntoI2cTiming for (Hertz, Hertz) {
-    fn into_i2c_timing(self) -> I2cTiming {
-        let (ker_ck, bus_freq) = self;
+impl IntoI2cTiming for Hertz {
+    fn into_i2c_timing(self, ker_ck: u32) -> I2cTiming {
         let (presc, scll, sclh, sdadel, scldel) =
-            calc_timing_params(ker_ck.raw(), bus_freq.raw());
-        I2cTiming { presc, scldel, sdadel, sclh, scll }
+            calc_timing_params(ker_ck, self.raw());
+        I2cTiming {
+            presc,
+            scldel,
+            sdadel,
+            sclh,
+            scll,
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::i2c::{I2cTiming, RawTimingr, calc_timing_params};
+    use crate::i2c::{
+        calc_timing_params, I2cTiming, IntoI2cTiming, RawTimingr,
+    };
     use crate::time::Hertz;
 
     /// Runs a timing testcase over PCLK and I2C clock ranges
@@ -1907,7 +1961,7 @@ mod tests {
         let sclh = 16;
         let scll = 48;
         let raw_timing = RawTimingr(timingr);
-        let t1: I2cTiming = raw_timing.into();
+        let t1 = raw_timing.into_i2c_timing(0);
         assert_eq!(t1.presc, presc);
         assert_eq!(t1.scldel, scldel);
         assert_eq!(t1.sdadel, sdadel);
@@ -1915,11 +1969,9 @@ mod tests {
         assert_eq!(t1.scll, scll);
 
         let t2 = I2cTiming::new(presc, scldel, sdadel, sclh, scll);
-        assert_eq!(timingr, t2.calc_register_value());
+        assert_eq!(timingr, RawTimingr::from(t2).0);
 
-        use crate::i2c::IntoI2cTiming;
-        // let t3 = 200_000u32.into_timing(250_000_000);
-        let t3 = (Hertz::from_raw(250_000_000), Hertz::from_raw(200_000)).into_i2c_timing();
-        assert_eq!(t3.calc_register_value(), 0xd39c050f);
+        let t3 = Hertz::from_raw(200_000).into_i2c_timing(250_000_000);
+        assert_eq!(RawTimingr::from(t3).0, 0xD0F51C39);
     }
 }

--- a/src/i2c/config.rs
+++ b/src/i2c/config.rs
@@ -5,10 +5,10 @@ use super::AddressMode;
 /// This structure uses the builder pattern to generate the configuration:
 ///
 /// ```
-/// let config = Config::new().secondary_address(0x10);
+/// let config = TargetConfig::new(own_addr).secondary_address(0x10);
 /// ```
 #[derive(Copy, Clone)]
-pub struct TargetConfig<T> {
+pub struct TargetConfig {
     /// Address mode of the MCU acting as a target
     pub(crate) own_address_mode: AddressMode,
     /// Target address for MCU
@@ -17,27 +17,18 @@ pub struct TargetConfig<T> {
     pub(crate) secondary_address: Option<u8>,
     // Address mask for secondary mask
     pub(crate) secondary_address_mask_bits: Option<u8>,
-    /// Frequency at which bus is expected to run.
-    pub(crate) timing: T,
 }
 
-impl<T> TargetConfig<T> {
-    /// Create a default configuration with the address of the MCU and the expected bus timing.
+impl TargetConfig {
+    /// Create a default configuration with the address of the MCU.
     ///
     /// The address should be specified unshifted. 7-bit addressing mode is used by default.
-    ///
-    /// `timing` accepts anything that implements [`IntoTimingRegister`]: a [`Hertz`] frequency,
-    /// a [`RawTimingr`] pre-computed register value, explicit `(u8,u8,u8,u8,u8)` parameters,
-    /// or a [`Timing`] struct.
-    /// If a frequency is provided, the driver will compute the timing register value based on the
-    /// timing requirements of the I2C bus and the source clock frequency.
-    pub const fn new(own_address: u16, timing: T) -> Self {
+    pub const fn new(own_address: u16) -> Self {
         TargetConfig {
             own_address_mode: AddressMode::AddressMode7bit,
             own_address,
             secondary_address: None,
             secondary_address_mask_bits: None,
-            timing,
         }
     }
 

--- a/src/i2c/config.rs
+++ b/src/i2c/config.rs
@@ -8,7 +8,7 @@ use super::AddressMode;
 /// let config = Config::new().secondary_address(0x10);
 /// ```
 #[derive(Copy, Clone)]
-pub struct TargetConfig {
+pub struct TargetConfig<T> {
     /// Address mode of the MCU acting as a target
     pub(crate) own_address_mode: AddressMode,
     /// Target address for MCU
@@ -18,23 +18,26 @@ pub struct TargetConfig {
     // Address mask for secondary mask
     pub(crate) secondary_address_mask_bits: Option<u8>,
     /// Frequency at which bus is expected to run.
-    pub(crate) bus_frequency_hz: u32,
+    pub(crate) timing: T,
 }
 
-impl TargetConfig {
-    /// Create a default configuration with the address of the MCU and the expected bus frequency.
+impl<T> TargetConfig<T> {
+    /// Create a default configuration with the address of the MCU and the expected bus timing.
     ///
     /// The address should be specified unshifted. 7-bit addressing mode is used by default.
     ///
-    /// If this is not known, use a lower bound in order to ensure that the correct timing
-    /// parameters are used.
-    pub const fn new(own_address: u16, bus_frequency_hz: u32) -> Self {
+    /// `timing` accepts anything that implements [`IntoTimingRegister`]: a [`Hertz`] frequency,
+    /// a [`RawTimingr`] pre-computed register value, explicit `(u8,u8,u8,u8,u8)` parameters,
+    /// or a [`Timing`] struct.
+    /// If a frequency is provided, the driver will compute the timing register value based on the
+    /// timing requirements of the I2C bus and the source clock frequency.
+    pub const fn new(own_address: u16, timing: T) -> Self {
         TargetConfig {
             own_address_mode: AddressMode::AddressMode7bit,
             own_address,
             secondary_address: None,
             secondary_address_mask_bits: None,
-            bus_frequency_hz,
+            timing,
         }
     }
 


### PR DESCRIPTION
This PR adds the ability to pass a custom value for the STM32's `TIMINGR` register when initializing an I2C peripheral. This adds the ability for the user to compute a value for the I2C timing calculations that is custom to their board. The idea is that this will provide more accurate values than the algorithm used when initializing the peripheral with only the desired bus frequency.

TIMINGR values can be generated using the official STM32CubeMX tool based on desired clock frequencies and measured rise and fall times. ST Micro also provides the AN4235 document and spreadsheet that uses a similar algorithm. Note that these algorithms use an iterative method to exhaustively search the space of possible values which is different from the one currently used in this HAL crate.