### PR TITLE
Add flash peripheral

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ fugit = "0.3.7"
 embedded-dma = "0.2"
 embedded-hal = "1.0.0"
 embedded-io = "0.7.1"
+embedded-storage = "0.3.1"
 defmt = { version = "1.0.0", optional = true }
 paste = "1.0.15"
 log = { version = "0.4.20", optional = true}

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ of support for peripherals is shown in the table below.
 | ADC        | ❌ | [#35](https://github.com/stm32-rs/stm32h5xx-hal/issues/35) | |
 | PWM        | ❌ | - | |
 | Rtc        | ❌ | - | |
-| Flash      | ❌ | - | |
+| Flash      | 🚧 | - | |
 
 ## Minimum supported Rust version
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ of support for peripherals is shown in the table below.
 | ADC        | ❌ | [#35](https://github.com/stm32-rs/stm32h5xx-hal/issues/35) | |
 | PWM        | ❌ | - | |
 | Rtc        | ❌ | - | |
-| Flash      | 🚧 | - | |
+| Flash      | ✅ | - | |
 
 ## Minimum supported Rust version
 

--- a/examples/flash.rs
+++ b/examples/flash.rs
@@ -7,7 +7,7 @@
 #![no_main]
 #![no_std]
 
-use cortex_m_rt::{entry, exception, interrupt};
+use cortex_m_rt::{entry, exception};
 use cortex_m_semihosting::debug;
 use stm32h5xx_hal::{pac, prelude::*};
 

--- a/examples/flash.rs
+++ b/examples/flash.rs
@@ -7,7 +7,7 @@
 #![no_main]
 #![no_std]
 
-use cortex_m_rt::{entry, exception};
+use cortex_m_rt::entry;
 use cortex_m_semihosting::debug;
 use stm32h5xx_hal::{pac, prelude::*};
 

--- a/examples/flash.rs
+++ b/examples/flash.rs
@@ -1,0 +1,96 @@
+//! Example of Flash erasing, writing and reading
+//!
+//! Tested on the following parts:
+//! - STM32H503 (NUCLEO-H503RB)
+
+// #![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use cortex_m_rt::{entry, exception, interrupt};
+use cortex_m_semihosting::debug;
+use stm32h5xx_hal::{pac, prelude::*};
+
+// traits for read, write and erase methods
+use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
+
+#[macro_use]
+mod utilities;
+use log::info;
+
+#[entry]
+fn main() -> ! {
+    utilities::logger::init();
+    let dp = pac::Peripherals::take().unwrap();
+
+    let pwr = dp.PWR.constrain();
+    let pwrcfg = pwr.vos0().freeze();
+
+    // Constrain and Freeze clock
+    let rcc = dp.RCC.constrain();
+    let _ = rcc.sys_ck(250.MHz()).freeze(pwrcfg, &dp.SBS);
+
+    info!("");
+    info!("stm32h5xx-hal example - Flash erase, write and read");
+    info!("");
+
+    let mut flash = dp.FLASH.flash();
+
+    let mut locked_flash = flash.user_flash();
+    let (bank, sector) =
+        locked_flash.region().bank_sector_iter().last().unwrap();
+
+    // Erase data in last sector in flash
+    {
+        let mut f = locked_flash.unlocked();
+        f.erase_sector(bank, sector.number as usize).unwrap();
+    }
+
+    let mut buf = [0xFFu8; 1024 * 2];
+    let mut read = [0u8; 1024 * 2];
+    locked_flash.read(sector.offset, &mut read).unwrap();
+    assert_eq!(read, buf);
+
+    // Fill up write buffer
+    let mut count = 0;
+    for b in buf.iter_mut() {
+        *b = count;
+        count += 1;
+        if count >= 100 {
+            count = 0;
+        }
+    }
+
+    {
+        let mut f = locked_flash.unlocked();
+        f.write(sector.offset, &buf).unwrap();
+    }
+
+    locked_flash.read(sector.offset, &mut read).unwrap();
+    assert_eq!(read, buf);
+
+    info!("Successfully erased, written and read back flash data");
+
+    loop {
+        debug::exit(debug::EXIT_SUCCESS)
+    }
+}
+
+#[exception]
+unsafe fn NonMaskableInt() {
+    info!("NMI exception");
+    let flash = pac::FLASH::steal();
+    let eccdetr = flash.eccdetr().read();
+    if eccdetr.eccd().bit_is_set() {
+        let addr = eccdetr.addr_ecc().bits();
+        info!("ECC error address: 0x{:08X}", addr);
+        if eccdetr.otp_ecc().bit_is_set() {
+            info!("ECC error detected in OTP");
+        } else {
+            info!("ECC error detected in flash");
+        }
+
+        // Clear ECC error flag
+        flash.eccdetr().write(|w| w.eccd().set_bit());
+    }
+}

--- a/examples/flash.rs
+++ b/examples/flash.rs
@@ -75,22 +75,3 @@ fn main() -> ! {
         debug::exit(debug::EXIT_SUCCESS)
     }
 }
-
-#[exception]
-unsafe fn NonMaskableInt() {
-    info!("NMI exception");
-    let flash = pac::FLASH::steal();
-    let eccdetr = flash.eccdetr().read();
-    if eccdetr.eccd().bit_is_set() {
-        let addr = eccdetr.addr_ecc().bits();
-        info!("ECC error address: 0x{:08X}", addr);
-        if eccdetr.otp_ecc().bit_is_set() {
-            info!("ECC error detected in OTP");
-        } else {
-            info!("ECC error detected in flash");
-        }
-
-        // Clear ECC error flag
-        flash.eccdetr().write(|w| w.eccd().set_bit());
-    }
-}

--- a/examples/flash_option_bytes.rs
+++ b/examples/flash_option_bytes.rs
@@ -28,7 +28,7 @@ fn main() -> ! {
     let _ = rcc.sys_ck(250.MHz()).freeze(pwrcfg, &dp.SBS);
 
     info!("");
-    info!("stm32h5xx-hal example - Flash erase, write and read");
+    info!("stm32h5xx-hal example - Flash Option Bytes");
     info!("");
 
     let mut flash = dp.FLASH.flash();
@@ -80,24 +80,5 @@ fn main() -> ! {
 
     loop {
         debug::exit(debug::EXIT_SUCCESS)
-    }
-}
-
-#[exception]
-unsafe fn NonMaskableInt() {
-    info!("NMI exception");
-    let flash = pac::FLASH::steal();
-    let eccdetr = flash.eccdetr().read();
-    if eccdetr.eccd().bit_is_set() {
-        let addr = eccdetr.addr_ecc().bits();
-        info!("ECC error address: 0x{:08X}", addr);
-        if eccdetr.otp_ecc().bit_is_set() {
-            info!("ECC error detected in OTP");
-        } else {
-            info!("ECC error detected in flash");
-        }
-
-        // Clear ECC error flag
-        flash.eccdetr().write(|w| w.eccd().set_bit());
     }
 }

--- a/examples/flash_option_bytes.rs
+++ b/examples/flash_option_bytes.rs
@@ -7,7 +7,7 @@
 #![no_main]
 #![no_std]
 
-use cortex_m_rt::{entry, exception};
+use cortex_m_rt::entry;
 use cortex_m_semihosting::debug;
 use stm32h5xx_hal::{pac, prelude::*};
 

--- a/examples/flash_option_bytes.rs
+++ b/examples/flash_option_bytes.rs
@@ -1,0 +1,103 @@
+//! Example of Flash erasing, writing and reading
+//!
+//! Tested on the following parts:
+//! - STM32H503 (NUCLEO-H503RB)
+
+// #![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use cortex_m_rt::{entry, exception};
+use cortex_m_semihosting::debug;
+use stm32h5xx_hal::{pac, prelude::*};
+
+#[macro_use]
+mod utilities;
+use log::info;
+
+#[entry]
+fn main() -> ! {
+    utilities::logger::init();
+    let dp = pac::Peripherals::take().unwrap();
+
+    let pwr = dp.PWR.constrain();
+    let pwrcfg = pwr.vos0().freeze();
+
+    // Constrain and Freeze clock
+    let rcc = dp.RCC.constrain();
+    let _ = rcc.sys_ck(250.MHz()).freeze(pwrcfg, &dp.SBS);
+
+    info!("");
+    info!("stm32h5xx-hal example - Flash erase, write and read");
+    info!("");
+
+    let mut flash = dp.FLASH.flash();
+
+    info!(
+        "WWDG_SW: {}",
+        flash.optsr_cur().read().wwdg_sw().bit_is_set()
+    );
+
+    // Attempting to modify an option byte without unlocking should have no effect
+    flash.optsr_prg().modify(|_, w| w.wwdg_sw().clear_bit());
+
+    info!(
+        "WWDG_SW: {}",
+        flash.optsr_cur().read().wwdg_sw().bit_is_set()
+    );
+
+    // Unlock option bytes, modify WWDG_SW and relock
+    {
+        let mut option_bytes = flash.unlock_option_bytes().unwrap();
+
+        option_bytes
+            .modify(|f| {
+                f.optsr_prg().modify(|_, w| w.wwdg_sw().clear_bit());
+            })
+            .unwrap();
+    }
+
+    info!(
+        "WWDG_SW: {}",
+        flash.optsr_cur().read().wwdg_sw().bit_is_set()
+    );
+
+    // Unlock option bytes, return WWDG_SW to its original state and relock
+    {
+        let mut option_bytes = flash.unlock_option_bytes().unwrap();
+
+        option_bytes
+            .modify(|f| {
+                f.optsr_prg().modify(|_, w| w.wwdg_sw().set_bit());
+            })
+            .unwrap();
+    }
+
+    info!(
+        "WWDG_SW: {}",
+        flash.optsr_cur().read().wwdg_sw().bit_is_set()
+    );
+
+    loop {
+        debug::exit(debug::EXIT_SUCCESS)
+    }
+}
+
+#[exception]
+unsafe fn NonMaskableInt() {
+    info!("NMI exception");
+    let flash = pac::FLASH::steal();
+    let eccdetr = flash.eccdetr().read();
+    if eccdetr.eccd().bit_is_set() {
+        let addr = eccdetr.addr_ecc().bits();
+        info!("ECC error address: 0x{:08X}", addr);
+        if eccdetr.otp_ecc().bit_is_set() {
+            info!("ECC error detected in OTP");
+        } else {
+            info!("ECC error detected in flash");
+        }
+
+        // Clear ECC error flag
+        flash.eccdetr().write(|w| w.eccd().set_bit());
+    }
+}

--- a/examples/flash_otp.rs
+++ b/examples/flash_otp.rs
@@ -11,7 +11,7 @@
 #![no_main]
 #![no_std]
 
-use cortex_m_rt::entry;
+use cortex_m_rt::{entry, exception};
 use cortex_m_semihosting::debug;
 use stm32h5xx_hal::{pac, prelude::*};
 

--- a/examples/flash_otp.rs
+++ b/examples/flash_otp.rs
@@ -11,7 +11,7 @@
 #![no_main]
 #![no_std]
 
-use cortex_m_rt::{entry, exception};
+use cortex_m_rt::entry;
 use cortex_m_semihosting::debug;
 use stm32h5xx_hal::{pac, prelude::*};
 
@@ -37,7 +37,7 @@ fn main() -> ! {
 
     let mut flash = dp.FLASH.flash();
 
-    let mut otp = flash.otp_data().unwrap();
+    let mut otp = flash.otp_data();
     info!("Reading data slot 0");
 
     // Reading unprogrammed OTP generates an ECC error, which triggers an NMI. The NMI handler

--- a/examples/flash_otp.rs
+++ b/examples/flash_otp.rs
@@ -1,0 +1,94 @@
+//! Example of OTP reading and programming.
+//!
+//! // WARNING: Programming OTP is irreversible. OTP programming is disabled by default in this
+//! example to prevent accidental programming during testing. Modify the code to enable
+//! (see note below)
+//!
+//! Tested on the following parts:
+//! - STM32H503 (NUCLEO-H503RB)
+
+// #![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use cortex_m_rt::{entry, exception};
+use cortex_m_semihosting::debug;
+use stm32h5xx_hal::{pac, prelude::*};
+
+#[macro_use]
+mod utilities;
+use log::info;
+
+#[entry]
+fn main() -> ! {
+    utilities::logger::init();
+    let dp = pac::Peripherals::take().unwrap();
+
+    let pwr = dp.PWR.constrain();
+    let pwrcfg = pwr.vos0().freeze();
+
+    // Constrain and Freeze clock
+    let rcc = dp.RCC.constrain();
+    let _ = rcc.sys_ck(250.MHz()).freeze(pwrcfg, &dp.SBS);
+
+    info!("");
+    info!("stm32h5xx-hal example - Flash erase, write and read");
+    info!("");
+
+    let mut flash = dp.FLASH.flash();
+
+    let mut otp = flash.otp_data().unwrap();
+    info!("Reading data slot 0");
+
+    // Reading unprogrammed OTP generates an ECC error, which triggers an NMI. The NMI handler
+    // is defined below and clears the ECC error flag, allowing the read to complete successfully
+    // and return 0xFFFF for unprogrammed slots.
+    let data = otp.read_value(0).unwrap();
+    info!("OTP data slot 0: {:4X}", data);
+
+    // WARNING: Programming OTP is irreversible. This block will permanently modify OTP slot 0 on
+    // this device. It is disabled by default to prevent accidental programming during testing.
+    // Remove `#[cfg(false)]` to enable OTP programming.
+    #[cfg(false)]
+    {
+        let mut unlocked_otp = otp.unlocked();
+        info!("Writing 0xBEEF to data slot 0");
+        unlocked_otp.program_value(0, 0xBEEF).unwrap();
+
+        // OTP locks when unlocked_otp goes out of scope
+    }
+
+    let data = otp.read_value(0).unwrap();
+    info!("OTP data slot 0: {:4X}", data);
+
+    assert!(
+        data == 0xBEEF,
+        "OTP read value does not match programmed value"
+    );
+
+    loop {
+        debug::exit(debug::EXIT_SUCCESS)
+    }
+}
+
+// The NMI handler is used to catch ECC errors from OTP reads. When an ECC error occurs,
+// the handler reads the ECC error details from the FLASH peripheral, logs the error and address,
+// and clears the ECC error flag.
+#[exception]
+unsafe fn NonMaskableInt() {
+    info!("NMI exception");
+    let flash = pac::FLASH::steal();
+    let eccdetr = flash.eccdetr().read();
+    if eccdetr.eccd().bit_is_set() {
+        let addr = eccdetr.addr_ecc().bits();
+        info!("ECC error address: 0x{:08X}", addr);
+        if eccdetr.otp_ecc().bit_is_set() {
+            info!("ECC error detected in OTP");
+        } else {
+            info!("ECC error detected in flash");
+        }
+
+        // Clear ECC error flag
+        flash.eccdetr().write(|w| w.eccd().set_bit());
+    }
+}

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -7,16 +7,13 @@
 //!
 //! # Examples
 //!
-//! - [Flash example](https://github.com/stm32-rs/stm32h7xx-hal/blob/master/examples/flash.rs)
+//! - examples/flash.rs - erasing, reading, writing
 //!
 //! # Supported devices
 //!
-//! | Reference Manual | Flash Sizes | Banks | Sector Size
-//! | --- | --- | --- | ---
-//! | RM0433 | 128kB, 1MB, 2MB | One or Two | 128kB
-//! | RM0399 | 1MB, 2MB | Two | 128kB
-//! | RM0455 | 128kB, 1MB, 2MB | One or Two | 8kB
-//! | RM0468 | 128kB, 512kB, 1MB | One | 128kB
+//! | Reference Manual | Flash Size | Banks | Sector Size |
+//! | --- | --- | --- | --- |
+//! | RM0492 | 128 kB | Two (64 kB each) | 8 kB |
 
 use core::iter;
 use core::ops::Deref;
@@ -33,13 +30,13 @@ pub const SECTOR_SIZE: usize = 0x2000; // 8kB
 // The maximum write size is 128 bits
 const USER_FLASH_MAX_WRITE_SIZE: usize = 16; // 128-bit
 
-/// Flash erase/program error. From RM0433 Rev 7. Section 4.7
+/// Flash erase/program error. From RM0492 Rev 3. Section 7.8
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy)]
 pub enum Error {
-    // Flash is busy
+    /// Flash is busy
     Busy,
-    // Previously incomplete operation
+    /// Previously incomplete operation
     Incomplete,
     /// The arguments are not properly aligned
     NotAligned,
@@ -52,7 +49,7 @@ pub enum Error {
     /// Application software wrote several times to the same byte
     Strobe,
     /// Write operation was attempted before the completion of the previous
-    /// write operation OR a wrap burst request overlaps two or more 256-bit
+    /// write operation OR a wrap burst request overlaps two or more 128-bit
     /// flash-word addresses
     Inconsistency,
     /// Error occurred during an option byte change operation
@@ -231,7 +228,11 @@ impl Flash {
         self.optkeyr()
             .write(|w| unsafe { w.optkey().bits(UNLOCK_KEY2) });
 
-        Ok(())
+        if self.optcr().read().optlock().bit_is_set() {
+            Err(Error::OptionByteChange)
+        } else {
+            Ok(())
+        }
     }
 
     fn lock_option_bytes(&self) {
@@ -263,15 +264,24 @@ impl Flash {
         Ok(ProgrammingRequest { flash: self })
     }
 
+    /// Returns a read-only handle to the user flash region.
+    ///
+    /// `FLASH_NSCR` is locked on return. Call [`LockedUserFlash::unlocked`] to
+    /// obtain a write guard that re-locks `FLASH_NSCR` on drop.
     pub fn user_flash(&mut self) -> LockedUserFlash<'_> {
-        self.unlock_configuration();
+        self.lock_configuration();
         LockedUserFlash::new(self)
     }
 
-    pub fn otp_data(&mut self) -> Result<LockedOtpData<'_>, Error> {
-        Ok(LockedOtpData::new(self))
+    /// Returns a read-only handle to the one time programmable data region.
+    pub fn otp_data(&mut self) -> LockedOtpData<'_> {
+        LockedOtpData::new(self)
     }
 
+    /// Unlocks the option byte control register (`FLASH_OPTCR`).
+    ///
+    /// Returns an [`UnlockedOptionBytes`] guard that re-locks `FLASH_OPTCR` on drop.
+    /// Returns `Err(Error::OptionByteChange)` if the hardware rejects the key sequence.
     pub fn unlock_option_bytes(
         &mut self,
     ) -> Result<UnlockedOptionBytes<'_>, Error> {
@@ -279,6 +289,7 @@ impl Flash {
         Ok(UnlockedOptionBytes { flash: self })
     }
 
+    /// Consumes the [`Flash`] wrapper and returns the raw `FLASH` peripheral.
     pub fn free(self) -> FLASH {
         self.flash
     }
@@ -287,8 +298,6 @@ impl Flash {
 struct ProgrammingRequest<'a> {
     flash: &'a Flash,
 }
-
-impl<'a> ProgrammingRequest<'a> {}
 
 impl<'a> Drop for ProgrammingRequest<'a> {
     fn drop(&mut self) {
@@ -301,14 +310,18 @@ pub struct LockedUserFlash<'a> {
 }
 
 impl<'a> LockedUserFlash<'a> {
-    pub fn new(flash: &'a mut Flash) -> Self {
+    pub(crate) fn new(flash: &'a mut Flash) -> Self {
         Self { flash }
     }
 
+    /// Returns the [`UserFlashRegion`] descriptor for this flash region.
     pub fn region(&self) -> UserFlashRegion {
         UserFlashRegion
     }
 
+    /// Unlocks `FLASH_NSCR` and returns an [`UnlockedUserFlash`] write guard.
+    ///
+    /// `FLASH_NSCR` is re-locked when the guard is dropped.
     pub fn unlocked(&mut self) -> UnlockedUserFlash<'_> {
         self.flash.unlock_configuration();
         UnlockedUserFlash::new(self.flash)
@@ -320,10 +333,11 @@ pub struct UnlockedUserFlash<'a> {
 }
 
 impl<'a> UnlockedUserFlash<'a> {
-    pub fn new(flash: &'a mut Flash) -> Self {
+    pub(crate) fn new(flash: &'a mut Flash) -> Self {
         Self { flash }
     }
 
+    /// Returns the [`UserFlashRegion`] descriptor for this flash region.
     pub fn region(&self) -> UserFlashRegion {
         UserFlashRegion
     }
@@ -366,7 +380,7 @@ impl UserFlashRegion {
     pub fn bank_sector_iter(
         &self,
     ) -> impl Iterator<Item = (usize, FlashSector)> {
-        // Second user main memory bank always starts at an offset of 0x10_0000
+        // Bank 1 starts at offset 0x0, bank 2 starts at bank_size() (64 kB = 0x1_0000 for H503)
         iter::repeat(0)
             .zip(FlashSectorIterator::new(0, 0, self.bank_size() as u32))
             .chain(iter::repeat(1).zip(FlashSectorIterator::new(
@@ -376,10 +390,13 @@ impl UserFlashRegion {
             )))
     }
 
+    /// Size in bytes of one physical flash bank
     pub fn bank_size(&self) -> usize {
         self.size() / 2
     }
 
+    /// Returns the byte offset from [`USER_FLASH_BASE_ADDRESS`] where `bank` starts.
+    /// Bank 0 is at offset 0; bank 1 immediately follows at `bank_size()` bytes.
     pub fn bank_offset(&self, bank: u32) -> u32 {
         match bank {
             0 => 0,
@@ -388,6 +405,7 @@ impl UserFlashRegion {
         }
     }
 
+    /// Returns the bank number that contains `offset`.
     pub fn bank(&self, offset: u32) -> u32 {
         offset / self.bank_size() as u32
     }
@@ -406,12 +424,17 @@ impl nor_flash::ReadNorFlash for LockedUserFlash<'_> {
         bytes: &mut [u8],
     ) -> Result<(), Self::Error> {
         let offset = offset as usize;
+        let end = offset.checked_add(bytes.len()).ok_or(Error::OutOfBounds)?;
+
+        if end > self.region().size() {
+            return Err(Error::OutOfBounds);
+        }
 
         let ptr = self.region().base_address() as *const _;
         let data =
             unsafe { core::slice::from_raw_parts(ptr, self.region().size()) };
 
-        bytes.copy_from_slice(&data[offset..offset + bytes.len()]);
+        bytes.copy_from_slice(&data[offset..end]);
         Ok(())
     }
 
@@ -433,12 +456,17 @@ impl nor_flash::ReadNorFlash for UnlockedUserFlash<'_> {
         bytes: &mut [u8],
     ) -> Result<(), Self::Error> {
         let offset = offset as usize;
+        let end = offset.checked_add(bytes.len()).ok_or(Error::OutOfBounds)?;
+
+        if end > self.region().size() {
+            return Err(Error::OutOfBounds);
+        }
 
         let ptr = self.region().base_address() as *const _;
         let data =
             unsafe { core::slice::from_raw_parts(ptr, self.region().size()) };
 
-        bytes.copy_from_slice(&data[offset..offset + bytes.len()]);
+        bytes.copy_from_slice(&data[offset..end]);
         Ok(())
     }
 
@@ -472,8 +500,9 @@ impl OtpDataRegion {
         OTP_BASE_ADDRESS + OTP_SIZE as u32
     }
 
-    fn block(&self, slot: usize) -> usize {
-        slot / OTP_SLOTS_PER_BLOCK
+    /// OTP block number containing `slot`.
+    pub fn block(&self, slot: usize) -> usize {
+        slot / 32
     }
 }
 
@@ -482,16 +511,24 @@ impl<'a> LockedOtpData<'a> {
         Self { flash }
     }
 
+    /// Returns the [`OtpDataRegion`] descriptor for the OTP area.
     pub fn region(&self) -> OtpDataRegion {
         OtpDataRegion
     }
 
+    /// Reads the 16-bit OTP word at `slot`.
+    ///
+    /// Panics if `slot` is out of range.
     pub fn read_value(&mut self, slot: usize) -> Result<u16, Error> {
         let ptr = self.region().base_address() as *const u16;
         let ptr = unsafe { ptr.add(slot) };
         assert!(ptr < self.region().region_end_address() as *const u16);
         Ok(unsafe { core::ptr::read_volatile(ptr) })
     }
+
+    /// Unlocks `FLASH_NSCR` and returns an [`UnlockedOtpData`] write guard.
+    ///
+    /// `FLASH_NSCR` is re-locked when the guard is dropped.
     pub fn unlocked(&mut self) -> UnlockedOtpData<'_> {
         self.flash.unlock_configuration();
         UnlockedOtpData::new(self.flash)
@@ -507,10 +544,14 @@ impl<'a> UnlockedOtpData<'a> {
         Self { flash }
     }
 
+    /// Returns the [`OtpDataRegion`] descriptor for the OTP area.
     pub fn region(&self) -> OtpDataRegion {
         OtpDataRegion
     }
 
+    /// Reads the 16-bit OTP word at `slot`.
+    ///
+    /// Panics if `slot` is out of range.
     pub fn read_value(&mut self, slot: usize) -> Result<u16, Error> {
         let ptr = self.region().base_address() as *const u16;
         let ptr = unsafe { ptr.add(slot) };
@@ -539,38 +580,14 @@ impl<'a> Drop for UnlockedOptionBytes<'a> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn flash_dual_bank_1m() {
-        let mut sectors = flash_sectors(1 * 1024 * 1024);
-
-        #[rustfmt::skip]
-        assert_eq!(sectors.next(), Some(FlashSector { number: 0, offset: 0x00000 }));
-        #[rustfmt::skip]
-        assert_eq!(sectors.next(), Some(FlashSector { number: 1, offset: 0x20000 }));
-        #[rustfmt::skip]
-        assert_eq!(sectors.next(), Some(FlashSector { number: 2, offset: 0x40000 }));
-        #[rustfmt::skip]
-        assert_eq!(sectors.next(), Some(FlashSector { number: 3, offset: 0x60000 }));
-        // Offsets 0x80000 - 0x100000 not available
-        #[rustfmt::skip]
-        assert_eq!(sectors.next(), Some(FlashSector { number: 0, offset: 0x100000 }));
-        #[rustfmt::skip]
-        assert_eq!(sectors.next(), Some(FlashSector { number: 1, offset: 0x120000 }));
-        #[rustfmt::skip]
-        assert_eq!(sectors.next(), Some(FlashSector { number: 2, offset: 0x140000 }));
-        #[rustfmt::skip]
-        assert_eq!(sectors.next(), Some(FlashSector { number: 3, offset: 0x160000 }));
-        // Offsets 0x180000 - 0x200000 not available
-        assert_eq!(sectors.next(), None);
-    }
-
-    /// Test the memory layout of the STM32H750xB and STM32H730
+    /// Test the memory layout of the STM32H503
     #[test]
     fn flash_single_bank_128k() {
-        let mut sectors = flash_sectors(128 * 1024);
-
-        #[rustfmt::skip]
-        assert_eq!(sectors.next(), Some(FlashSector { number: 0, offset: 0x00000 }));
-        assert_eq!(sectors.next(), None);
+        let iter = FlashSectorIterator::new(0, 0, 128 * 1024);
+        let sectors: Vec<FlashSector> = iter.collect();
+        let last = sectors.last().unwrap();
+        assert_eq!(sectors.len(), 16);
+        assert_eq!(last.number, 15);
+        assert_eq!(last.offset, 15 * SECTOR_SIZE as u32);
     }
 }

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -1,0 +1,576 @@
+//! Embedded Flash memory
+//!
+//! Support for Read, Write and Erase options on the Embedded Flash memory. This
+//! module implements traits from the
+//! [embedded-storage](https://github.com/rust-embedded-community/embedded-storage)
+//! crate.
+//!
+//! # Examples
+//!
+//! - [Flash example](https://github.com/stm32-rs/stm32h7xx-hal/blob/master/examples/flash.rs)
+//!
+//! # Supported devices
+//!
+//! | Reference Manual | Flash Sizes | Banks | Sector Size
+//! | --- | --- | --- | ---
+//! | RM0433 | 128kB, 1MB, 2MB | One or Two | 128kB
+//! | RM0399 | 1MB, 2MB | Two | 128kB
+//! | RM0455 | 128kB, 1MB, 2MB | One or Two | 8kB
+//! | RM0468 | 128kB, 512kB, 1MB | One | 128kB
+
+use core::iter;
+use core::ops::Deref;
+
+use crate::signature::FlashSize;
+use crate::stm32::FLASH;
+use embedded_storage::{nor_flash, Region};
+
+mod operations;
+
+// All sectors in the user main memory sectors have the same size.
+pub const SECTOR_SIZE: usize = 0x2000; // 8kB
+
+// The maximum write size is 128 bits
+const USER_FLASH_MAX_WRITE_SIZE: usize = 16; // 128-bit
+
+/// Flash erase/program error. From RM0433 Rev 7. Section 4.7
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy)]
+pub enum Error {
+    // Flash is busy
+    Busy,
+    // Previously incomplete operation
+    Incomplete,
+    /// The arguments are not properly aligned
+    NotAligned,
+    /// The arguments are out of bounds
+    OutOfBounds,
+    /// An illegal erase/program operation was attempted
+    WriteProtection,
+    /// The programming sequence was incorrect
+    ProgrammingSequence,
+    /// Application software wrote several times to the same byte
+    Strobe,
+    /// Write operation was attempted before the completion of the previous
+    /// write operation OR a wrap burst request overlaps two or more 256-bit
+    /// flash-word addresses
+    Inconsistency,
+    /// Error occurred during an option byte change operation
+    OptionByteChange,
+    /// Other errors
+    Other,
+}
+
+/// Flash memory sector
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct FlashSector {
+    /// Sector number
+    pub number: u8,
+    /// Offset from base memory address
+    pub offset: u32,
+}
+
+impl Region for FlashSector {
+    /// Returns true if given offset belongs to this sector
+    fn contains(&self, offset: u32) -> bool {
+        (self.offset <= offset) && (offset < (self.offset + SECTOR_SIZE as u32))
+    }
+}
+
+/// Iterator of flash memory sectors within a single bank
+pub struct FlashSectorIterator {
+    index: u8,
+    start_sector: u8,
+    start_offset: u32,
+    end_offset: u32,
+}
+impl FlashSectorIterator {
+    fn new(start_sector: u8, start_offset: u32, end_offset: u32) -> Self {
+        Self {
+            index: 0,
+            start_sector,
+            start_offset,
+            end_offset,
+        }
+    }
+}
+impl Iterator for FlashSectorIterator {
+    type Item = FlashSector;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.start_offset >= self.end_offset {
+            None
+        } else {
+            let sector = FlashSector {
+                number: self.start_sector + self.index,
+                offset: self.start_offset,
+            };
+
+            self.index += 1;
+            self.start_offset += SECTOR_SIZE as u32;
+
+            Some(sector)
+        }
+    }
+}
+
+/// Flash methods implemented for `pac::FLASH`
+pub trait FlashExt {
+    fn flash(self) -> Flash;
+}
+
+const USER_FLASH_BASE_ADDRESS: u32 = 0x0800_0000;
+
+impl FlashExt for FLASH {
+    fn flash(self) -> Flash {
+        Flash { flash: self }
+    }
+}
+
+pub struct Flash {
+    flash: FLASH,
+}
+
+impl Deref for Flash {
+    type Target = FLASH;
+
+    fn deref(&self) -> &Self::Target {
+        &self.flash
+    }
+}
+
+impl Flash {
+    fn is_configuration_locked(&self) -> bool {
+        self.nscr().read().lock().bit_is_set()
+    }
+
+    fn is_busy(&self) -> bool {
+        self.nssr().read().bsy().bit_is_set()
+    }
+
+    fn check_write_buffer_empty(&self) -> Result<(), Error> {
+        if self.nssr().read().wbne().bit_is_set() {
+            Err(Error::Incomplete)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn check_busy(&self) -> Result<(), Error> {
+        if self.is_busy() {
+            Err(Error::Busy)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn wait_ready(&self) {
+        while self.is_busy() {}
+    }
+
+    fn wait_data_buffer_empty(&self) {
+        while self.nssr().read().dbne().bit_is_set() {}
+    }
+
+    fn check_error(&self) -> Result<(), Error> {
+        let sr = self.nssr().read();
+
+        if sr.wrperr().bit_is_set() {
+            Err(Error::WriteProtection)
+        } else if sr.pgserr().bit_is_set() {
+            Err(Error::ProgrammingSequence)
+        } else if sr.strberr().bit_is_set() {
+            Err(Error::Strobe)
+        } else if sr.incerr().bit_is_set() {
+            Err(Error::Inconsistency)
+        } else if sr.optchangeerr().bit_is_set() {
+            Err(Error::OptionByteChange)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn clear_error_flags(&self) {
+        self.nsccr().write(|w| {
+            w.clr_wrperr()
+                .set_bit()
+                .clr_pgserr()
+                .set_bit()
+                .clr_strberr()
+                .set_bit()
+                .clr_incerr()
+                .set_bit()
+                .clr_optchangeerr()
+                .set_bit()
+        });
+    }
+
+    fn unlock_configuration(&self) {
+        if self.is_configuration_locked() {
+            const UNLOCK_KEY1: u32 = 0x4567_0123;
+            const UNLOCK_KEY2: u32 = 0xCDEF_89AB;
+
+            self.nskeyr()
+                .write(|w| unsafe { w.nskey().bits(UNLOCK_KEY1) });
+            self.nskeyr()
+                .write(|w| unsafe { w.nskey().bits(UNLOCK_KEY2) });
+            assert!(!self.is_configuration_locked())
+        }
+    }
+
+    fn lock_configuration(&self) {
+        self.nscr().modify(|_, w| w.lock().set_bit());
+    }
+
+    fn unlock_option_byte_control(&self) -> Result<(), Error> {
+        const UNLOCK_KEY1: u32 = 0x0819_2A3B;
+        const UNLOCK_KEY2: u32 = 0x4C5D_6E7F;
+
+        self.optkeyr()
+            .write(|w| unsafe { w.optkey().bits(UNLOCK_KEY1) });
+        self.optkeyr()
+            .write(|w| unsafe { w.optkey().bits(UNLOCK_KEY2) });
+
+        Ok(())
+    }
+
+    fn lock_option_bytes(&self) {
+        self.optcr().modify(|_, w| w.optlock().set_bit());
+    }
+
+    fn enable_programming(&self) {
+        self.nscr().modify(|_, w| w.pg().set_bit());
+    }
+
+    fn disable_programming(&self) {
+        self.nscr().modify(|_, w| w.pg().clear_bit());
+    }
+
+    fn prepare_operation(&self) -> Result<(), Error> {
+        // Ensure no effective write, erase or option byte change operation is ongoing
+        self.check_busy()?;
+        // Check that previous write operation completed successfully
+        self.check_write_buffer_empty()?;
+        // Wait for data buffer to be empty
+        self.wait_data_buffer_empty();
+        Ok(())
+    }
+
+    fn programming_request(&self) -> Result<ProgrammingRequest<'_>, Error> {
+        self.prepare_operation()?;
+        self.enable_programming();
+
+        Ok(ProgrammingRequest { flash: self })
+    }
+
+    pub fn user_flash(&mut self) -> LockedUserFlash<'_> {
+        self.unlock_configuration();
+        LockedUserFlash::new(self)
+    }
+
+    pub fn otp_data(&mut self) -> Result<LockedOtpData<'_>, Error> {
+        Ok(LockedOtpData::new(self))
+    }
+
+    pub fn unlock_option_bytes(
+        &mut self,
+    ) -> Result<UnlockedOptionBytes<'_>, Error> {
+        self.unlock_option_byte_control()?;
+        Ok(UnlockedOptionBytes { flash: self })
+    }
+
+    pub fn free(self) -> FLASH {
+        self.flash
+    }
+}
+
+struct ProgrammingRequest<'a> {
+    flash: &'a Flash,
+}
+
+impl<'a> ProgrammingRequest<'a> {}
+
+impl<'a> Drop for ProgrammingRequest<'a> {
+    fn drop(&mut self) {
+        self.flash.disable_programming();
+    }
+}
+
+pub struct LockedUserFlash<'a> {
+    flash: &'a mut Flash,
+}
+
+impl<'a> LockedUserFlash<'a> {
+    pub fn new(flash: &'a mut Flash) -> Self {
+        Self { flash }
+    }
+
+    pub fn region(&self) -> UserFlashRegion {
+        UserFlashRegion
+    }
+
+    pub fn unlocked(&mut self) -> UnlockedUserFlash<'_> {
+        self.flash.unlock_configuration();
+        UnlockedUserFlash::new(self.flash)
+    }
+}
+
+pub struct UnlockedUserFlash<'a> {
+    flash: &'a mut Flash,
+}
+
+impl<'a> UnlockedUserFlash<'a> {
+    pub fn new(flash: &'a mut Flash) -> Self {
+        Self { flash }
+    }
+
+    pub fn region(&self) -> UserFlashRegion {
+        UserFlashRegion
+    }
+}
+
+impl<'a> Drop for UnlockedUserFlash<'a> {
+    fn drop(&mut self) {
+        self.flash.lock_configuration();
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct UserFlashRegion;
+
+impl UserFlashRegion {
+    /// Memory-mapped address
+    pub fn base_address(&self) -> u32 {
+        USER_FLASH_BASE_ADDRESS
+    }
+    /// Size in bytes
+    pub fn size(&self) -> usize {
+        FlashSize::bytes()
+    }
+
+    /// Returns flash memory sector of a given offset. Returns none if offset is
+    /// out of range
+    pub fn sector(&self, offset: u32) -> FlashSector {
+        assert!(offset < self.size() as u32);
+        let bank = self.bank(offset);
+        let offset_within_bank = offset - self.bank_offset(bank);
+        FlashSector {
+            number: (offset_within_bank / SECTOR_SIZE as u32) as u8,
+            offset,
+        }
+    }
+
+    /// Returns iterator of flash memory sectors
+    ///
+    /// Sectors are returned in memory order
+    pub fn bank_sector_iter(
+        &self,
+    ) -> impl Iterator<Item = (usize, FlashSector)> {
+        // Second user main memory bank always starts at an offset of 0x10_0000
+        iter::repeat(0)
+            .zip(FlashSectorIterator::new(0, 0, self.bank_size() as u32))
+            .chain(iter::repeat(1).zip(FlashSectorIterator::new(
+                0,
+                self.bank_size() as u32,
+                self.size() as u32,
+            )))
+    }
+
+    pub fn bank_size(&self) -> usize {
+        self.size() / 2
+    }
+
+    pub fn bank_offset(&self, bank: u32) -> u32 {
+        match bank {
+            0 => 0,
+            1 => self.bank_size() as u32,
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn bank(&self, offset: u32) -> u32 {
+        offset / self.bank_size() as u32
+    }
+}
+
+impl nor_flash::ErrorType for LockedUserFlash<'_> {
+    type Error = Error;
+}
+
+impl nor_flash::ReadNorFlash for LockedUserFlash<'_> {
+    const READ_SIZE: usize = 1;
+
+    fn read(
+        &mut self,
+        offset: u32,
+        bytes: &mut [u8],
+    ) -> Result<(), Self::Error> {
+        let offset = offset as usize;
+
+        let ptr = self.region().base_address() as *const _;
+        let data =
+            unsafe { core::slice::from_raw_parts(ptr, self.region().size()) };
+
+        bytes.copy_from_slice(&data[offset..offset + bytes.len()]);
+        Ok(())
+    }
+
+    fn capacity(&self) -> usize {
+        self.region().size()
+    }
+}
+
+impl nor_flash::ErrorType for UnlockedUserFlash<'_> {
+    type Error = Error;
+}
+
+impl nor_flash::ReadNorFlash for UnlockedUserFlash<'_> {
+    const READ_SIZE: usize = 1;
+
+    fn read(
+        &mut self,
+        offset: u32,
+        bytes: &mut [u8],
+    ) -> Result<(), Self::Error> {
+        let offset = offset as usize;
+
+        let ptr = self.region().base_address() as *const _;
+        let data =
+            unsafe { core::slice::from_raw_parts(ptr, self.region().size()) };
+
+        bytes.copy_from_slice(&data[offset..offset + bytes.len()]);
+        Ok(())
+    }
+
+    fn capacity(&self) -> usize {
+        self.region().size()
+    }
+}
+
+pub const OTP_BASE_ADDRESS: u32 = 0x08FF_F000;
+pub const OTP_SIZE: usize = 2048;
+pub const OTP_SLOTS_PER_BLOCK: usize = 32;
+pub const OTP_NUM_SLOTS: usize = OTP_SIZE / core::mem::size_of::<u16>();
+
+pub struct LockedOtpData<'a> {
+    flash: &'a mut Flash,
+}
+
+pub struct OtpDataRegion;
+
+impl OtpDataRegion {
+    /// Memory-mapped address
+    pub fn base_address(&self) -> u32 {
+        OTP_BASE_ADDRESS
+    }
+    /// Size in bytes
+    pub fn size(&self) -> usize {
+        OTP_SIZE
+    }
+
+    fn region_end_address(&self) -> u32 {
+        OTP_BASE_ADDRESS + OTP_SIZE as u32
+    }
+
+    fn block(&self, slot: usize) -> usize {
+        slot / OTP_SLOTS_PER_BLOCK
+    }
+}
+
+impl<'a> LockedOtpData<'a> {
+    fn new(flash: &'a mut Flash) -> Self {
+        Self { flash }
+    }
+
+    pub fn region(&self) -> OtpDataRegion {
+        OtpDataRegion
+    }
+
+    pub fn read_value(&mut self, slot: usize) -> Result<u16, Error> {
+        let ptr = self.region().base_address() as *const u16;
+        let ptr = unsafe { ptr.add(slot) };
+        assert!(ptr < self.region().region_end_address() as *const u16);
+        Ok(unsafe { core::ptr::read_volatile(ptr) })
+    }
+    pub fn unlocked(&mut self) -> UnlockedOtpData<'_> {
+        self.flash.unlock_configuration();
+        UnlockedOtpData::new(self.flash)
+    }
+}
+
+pub struct UnlockedOtpData<'a> {
+    flash: &'a mut Flash,
+}
+
+impl<'a> UnlockedOtpData<'a> {
+    fn new(flash: &'a mut Flash) -> Self {
+        Self { flash }
+    }
+
+    pub fn region(&self) -> OtpDataRegion {
+        OtpDataRegion
+    }
+
+    pub fn read_value(&mut self, slot: usize) -> Result<u16, Error> {
+        let ptr = self.region().base_address() as *const u16;
+        let ptr = unsafe { ptr.add(slot) };
+        assert!(ptr < self.region().region_end_address() as *mut u16);
+        Ok(unsafe { core::ptr::read_volatile(ptr) })
+    }
+}
+
+impl<'a> Drop for UnlockedOtpData<'a> {
+    fn drop(&mut self) {
+        self.flash.lock_configuration();
+    }
+}
+
+pub struct UnlockedOptionBytes<'a> {
+    flash: &'a mut Flash,
+}
+
+impl<'a> Drop for UnlockedOptionBytes<'a> {
+    fn drop(&mut self) {
+        self.flash.lock_option_bytes();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flash_dual_bank_1m() {
+        let mut sectors = flash_sectors(1 * 1024 * 1024);
+
+        #[rustfmt::skip]
+        assert_eq!(sectors.next(), Some(FlashSector { number: 0, offset: 0x00000 }));
+        #[rustfmt::skip]
+        assert_eq!(sectors.next(), Some(FlashSector { number: 1, offset: 0x20000 }));
+        #[rustfmt::skip]
+        assert_eq!(sectors.next(), Some(FlashSector { number: 2, offset: 0x40000 }));
+        #[rustfmt::skip]
+        assert_eq!(sectors.next(), Some(FlashSector { number: 3, offset: 0x60000 }));
+        // Offsets 0x80000 - 0x100000 not available
+        #[rustfmt::skip]
+        assert_eq!(sectors.next(), Some(FlashSector { number: 0, offset: 0x100000 }));
+        #[rustfmt::skip]
+        assert_eq!(sectors.next(), Some(FlashSector { number: 1, offset: 0x120000 }));
+        #[rustfmt::skip]
+        assert_eq!(sectors.next(), Some(FlashSector { number: 2, offset: 0x140000 }));
+        #[rustfmt::skip]
+        assert_eq!(sectors.next(), Some(FlashSector { number: 3, offset: 0x160000 }));
+        // Offsets 0x180000 - 0x200000 not available
+        assert_eq!(sectors.next(), None);
+    }
+
+    /// Test the memory layout of the STM32H750xB and STM32H730
+    #[test]
+    fn flash_single_bank_128k() {
+        let mut sectors = flash_sectors(128 * 1024);
+
+        #[rustfmt::skip]
+        assert_eq!(sectors.next(), Some(FlashSector { number: 0, offset: 0x00000 }));
+        assert_eq!(sectors.next(), None);
+    }
+}

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -8,12 +8,16 @@
 //! # Examples
 //!
 //! - examples/flash.rs - erasing, reading, writing
+//! - examples/flash_option_bytes.rs - setting & reading option bytes
+//! - examples/flash.rs - erasing, reading, writing
 //!
 //! # Supported devices
 //!
-//! | Reference Manual | Flash Size | Banks | Sector Size |
-//! | --- | --- | --- | --- |
-//! | RM0492 | 128 kB | Two (64 kB each) | 8 kB |
+//! | Reference Manual | Devices | Flash Size | Banks | Sector Size |
+//! | --- | --- | --- | --- | --- |
+//! | RM0492 | STM32H503 | 128 kB | Two (64 kB each) | 8 kB |
+//! | RM0481 | STM32H523/H533 | 256 kB | Two (128 kB each) | 8 kB |
+//! | RM0481 | STM32H562/H563/H573 | up to 2 MB | Two (up to 1 MB each) | 8 kB |
 
 use core::iter;
 use core::ops::Deref;
@@ -30,7 +34,7 @@ pub const SECTOR_SIZE: usize = 0x2000; // 8kB
 // The maximum write size is 128 bits
 const USER_FLASH_MAX_WRITE_SIZE: usize = 16; // 128-bit
 
-/// Flash erase/program error. From RM0492 Rev 3. Section 7.8
+/// Flash erase/program error.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy)]
 pub enum Error {
@@ -380,7 +384,7 @@ impl UserFlashRegion {
     pub fn bank_sector_iter(
         &self,
     ) -> impl Iterator<Item = (usize, FlashSector)> {
-        // Bank 1 starts at offset 0x0, bank 2 starts at bank_size() (64 kB = 0x1_0000 for H503)
+        // Bank 1 starts at offset 0x0, bank 2 starts at bank_size()
         iter::repeat(0)
             .zip(FlashSectorIterator::new(0, 0, self.bank_size() as u32))
             .chain(iter::repeat(1).zip(FlashSectorIterator::new(

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -270,10 +270,10 @@ impl Flash {
 
     /// Returns a read-only handle to the user flash region.
     ///
-    /// `FLASH_NSCR` is locked on return. Call [`LockedUserFlash::unlocked`] to
-    /// obtain a write guard that re-locks `FLASH_NSCR` on drop.
+    /// `FLASH_NSCR` is locked (by hardware reset state and the `Drop` impl on
+    /// [`UnlockedUserFlash`]). Call [`LockedUserFlash::unlocked`] to obtain a
+    /// write guard that re-locks `FLASH_NSCR` on drop.
     pub fn user_flash(&mut self) -> LockedUserFlash<'_> {
-        self.lock_configuration();
         LockedUserFlash::new(self)
     }
 

--- a/src/flash/operations.rs
+++ b/src/flash/operations.rs
@@ -3,7 +3,9 @@
 use core::ptr;
 use core::sync::atomic::{fence, Ordering};
 
-use embedded_storage::nor_flash::{NorFlash, NorFlashError, NorFlashErrorKind};
+use embedded_storage::nor_flash::{
+    check_erase, NorFlash, NorFlashError, NorFlashErrorKind,
+};
 use embedded_storage::Region;
 
 use crate::stm32::FLASH;
@@ -23,32 +25,29 @@ impl NorFlashError for Error {
     }
 }
 
-/// Result of `FlashExt::unlocked()`
+/// Erase and program operations for unlocked user flash
 ///
 /// # Examples
 ///
-/// ```
+/// ```no_run
 /// use stm32h5xx_hal::pac::Peripherals;
-/// use stm32h5xx_hal::flash::{FlashExt, LockedFlash, UnlockedFlashBank};
+/// use stm32h5xx_hal::flash::FlashExt;
 /// use embedded_storage::nor_flash::NorFlash;
 ///
 /// let dp = Peripherals::take().unwrap();
-/// let (mut flash, _) = dp.FLASH.split();
+/// let mut flash = dp.FLASH.flash();
+/// let mut user_flash = flash.user_flash();
+/// let mut unlocked = user_flash.unlocked();
 ///
-/// // Unlock flash for writing
-/// let mut unlocked_flash = flash.unlocked();
+/// // Erase the second 8 kB sector (bank 0, sector 1).
+/// NorFlash::erase(&mut unlocked, 1 * 8 * 1024, 2 * 8 * 1024).unwrap();
 ///
-/// // Erase the second 128 KB sector.
-/// NorFlash::erase(&mut unlocked_flash, 128 * 1024, 256 * 1024).unwrap();
+/// // Write 16 bytes (one 128-bit flash word) at the start of sector 1.
+/// let buf = [0u8; 16];
+/// NorFlash::write(&mut unlocked, 1 * 8 * 1024, &buf).unwrap();
 ///
-/// // Write some data at the start of the second 128 KB sector.
-/// let buf = [0u8; 64];
-/// NorFlash::write(&mut unlocked_flash, 128 * 1024, &buf).unwrap();
-///
-/// // Lock flash by dropping
-/// drop(unlocked_flash);
+/// // Flash is re-locked when `unlocked` is dropped.
 /// ```
-
 impl UnlockedUserFlash<'_> {
     /// Erase a flash sector
     ///
@@ -64,6 +63,7 @@ impl UnlockedUserFlash<'_> {
         }
 
         self.flash.wait_ready();
+        self.flash.prepare_operation()?;
 
         // Clear all the error flags due to previous programming/erase
         self.flash.clear_error_flags();
@@ -153,7 +153,16 @@ impl NorFlash for UnlockedUserFlash<'_> {
     const ERASE_SIZE: usize = super::SECTOR_SIZE;
 
     fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+        check_erase(self, from, to).map_err(|e| match e {
+            NorFlashErrorKind::NotAligned => Error::NotAligned,
+            NorFlashErrorKind::OutOfBounds => Error::OutOfBounds,
+            _ => Error::Other,
+        })?;
+
         let mut current = from;
+        if to > from {
+            return Err(Error::OutOfBounds);
+        }
 
         for (bank, sector) in self.region().bank_sector_iter() {
             if sector.contains(current) {
@@ -169,11 +178,23 @@ impl NorFlash for UnlockedUserFlash<'_> {
     }
 
     fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
+        if !(offset as usize).is_multiple_of(Self::WRITE_SIZE)
+            || !bytes.len().is_multiple_of(Self::WRITE_SIZE)
+        {
+            return Err(Error::NotAligned);
+        }
+        if offset as usize + bytes.len() > self.region().size() {
+            return Err(Error::OutOfBounds);
+        }
         self.program(offset, bytes.iter())
     }
 }
 
 impl<'a> UnlockedOtpData<'a> {
+    /// Programs a single 16-bit word into an OTP `slot`.
+    ///
+    /// Returns an error if the hardware signals a programming fault.
+    /// Panics if `slot >= OTP_NUM_SLOTS`.
     pub fn program_value(
         &mut self,
         slot: usize,
@@ -183,7 +204,10 @@ impl<'a> UnlockedOtpData<'a> {
 
         self.flash.wait_ready();
 
-        // TODO: Check if block is locked
+        if self.is_otp_block_locked(self.region().block(slot)) {
+            return Err(Error::WriteProtection);
+        }
+
         {
             // Unlock programming and ensure it is locked again on drop (at the end of this block)
             let _request = self.flash.programming_request()?;
@@ -211,6 +235,11 @@ impl<'a> UnlockedOtpData<'a> {
         self.read_value(slot)
     }
 
+    /// Programs consecutive 16-bit OTP words starting at `start_slot`.
+    ///
+    /// Each word in `words` is written to `start_slot + n` and verified before
+    /// the next word is written.  Returns an error on the first hardware fault.
+    /// Panics if `start_slot >= OTP_NUM_SLOTS` or any derived slot is out of range.
     pub fn program_sequence<I>(
         &mut self,
         start_slot: usize,
@@ -231,6 +260,12 @@ impl<'a> UnlockedOtpData<'a> {
             self.flash.clear_error_flags();
 
             for (slot, word) in words.enumerate() {
+                if self
+                    .is_otp_block_locked(self.region().block(start_slot + slot))
+                {
+                    return Err(Error::WriteProtection);
+                }
+
                 // Ensure that the write to the CR register (device memory) is
                 // committed *before* we write to flash (normal memory). This
                 // prevents ProgrammingSequence errors
@@ -255,6 +290,10 @@ impl<'a> UnlockedOtpData<'a> {
         Ok(())
     }
 
+    /// Programs raw bytes into the OTP region starting at byte `offset`.
+    ///
+    /// Returns an error on the first hardware fault.
+    /// Panics if `offset` is unaligned or any derived address exceeds the OTP region.
     pub fn program_bytes<I>(
         &mut self,
         offset: usize,
@@ -279,6 +318,11 @@ impl<'a> UnlockedOtpData<'a> {
             let mut count = 0usize;
 
             while bytes.peek().is_some() {
+                let slot = offset / 2 + count;
+                if self.is_otp_block_locked(self.region().block(slot)) {
+                    return Err(Error::WriteProtection);
+                }
+
                 // Ensure that the write to the CR register (device memory) is
                 // committed *before* we write to flash (normal memory). This
                 // prevents ProgrammingSequence errors
@@ -307,9 +351,16 @@ impl<'a> UnlockedOtpData<'a> {
 
         Ok(())
     }
+
+    fn is_otp_block_locked(&self, block: usize) -> bool {
+        let bits = self.flash.otpblr_cur().read().lockbl().bits();
+        (bits >> block) & 1 != 0
+    }
 }
 
 impl<'a> UnlockedOptionBytes<'a> {
+    /// Applies option-byte changes via a closure and starts the option-byte
+    /// programming sequence (`OPTSTRT`).
     pub fn modify<F>(&mut self, f: F) -> Result<(), Error>
     where
         F: FnOnce(&mut FLASH),

--- a/src/flash/operations.rs
+++ b/src/flash/operations.rs
@@ -1,0 +1,339 @@
+//! Erase, write, read operations for Flash
+
+use core::ptr;
+use core::sync::atomic::{fence, Ordering};
+
+use embedded_storage::nor_flash::{NorFlash, NorFlashError, NorFlashErrorKind};
+use embedded_storage::Region;
+
+use crate::stm32::FLASH;
+
+use super::{
+    Error, UnlockedOptionBytes, UnlockedOtpData, UnlockedUserFlash,
+    OTP_NUM_SLOTS, USER_FLASH_MAX_WRITE_SIZE,
+};
+
+impl NorFlashError for Error {
+    fn kind(&self) -> NorFlashErrorKind {
+        match &self {
+            Error::NotAligned => NorFlashErrorKind::NotAligned,
+            Error::OutOfBounds => NorFlashErrorKind::OutOfBounds,
+            _ => NorFlashErrorKind::Other,
+        }
+    }
+}
+
+/// Result of `FlashExt::unlocked()`
+///
+/// # Examples
+///
+/// ```
+/// use stm32h5xx_hal::pac::Peripherals;
+/// use stm32h5xx_hal::flash::{FlashExt, LockedFlash, UnlockedFlashBank};
+/// use embedded_storage::nor_flash::NorFlash;
+///
+/// let dp = Peripherals::take().unwrap();
+/// let (mut flash, _) = dp.FLASH.split();
+///
+/// // Unlock flash for writing
+/// let mut unlocked_flash = flash.unlocked();
+///
+/// // Erase the second 128 KB sector.
+/// NorFlash::erase(&mut unlocked_flash, 128 * 1024, 256 * 1024).unwrap();
+///
+/// // Write some data at the start of the second 128 KB sector.
+/// let buf = [0u8; 64];
+/// NorFlash::write(&mut unlocked_flash, 128 * 1024, &buf).unwrap();
+///
+/// // Lock flash by dropping
+/// drop(unlocked_flash);
+/// ```
+
+impl UnlockedUserFlash<'_> {
+    /// Erase a flash sector
+    ///
+    /// Refer to the reference manual to see which sector corresponds to which
+    /// memory address. Out of bounds sectors will cause an error.
+    pub fn erase_sector(
+        &mut self,
+        bank: usize,
+        sector: usize,
+    ) -> Result<(), Error> {
+        if sector * super::SECTOR_SIZE >= self.region().bank_size() {
+            return Err(Error::OutOfBounds);
+        }
+
+        self.flash.wait_ready();
+
+        // Clear all the error flags due to previous programming/erase
+        self.flash.clear_error_flags();
+
+        self.flash.nscr().modify(|_, w| unsafe {
+            match bank {
+                0 => w.bksel().clear_bit(),
+                1 => w.bksel().set_bit(),
+                _ => unreachable!(),
+            }
+            .ser()
+            .set_bit()
+            .snb()
+            .bits(sector as u8)
+            .strt()
+            .set_bit()
+        });
+        self.flash.wait_ready();
+
+        self.flash.nscr().modify(|_, w| w.ser().clear_bit());
+
+        self.flash.check_error()
+    }
+
+    /// Program bytes with offset into flash memory
+    ///
+    /// This method always issues writes with an alignment and size of 128 bits
+    /// by padding the first and last writes with 0xFF if needed.
+    pub fn program<'a, I>(&mut self, offset: u32, bytes: I) -> Result<(), Error>
+    where
+        I: Iterator<Item = &'a u8>,
+    {
+        self.flash.wait_ready();
+        // Unlock programming and ensure it is locked again on drop
+        let _request = self.flash.programming_request()?;
+
+        // prepend padding to align the offset to the write_size
+        let padding = offset as usize % USER_FLASH_MAX_WRITE_SIZE;
+        let mut bytes = (0..padding).map(|_| &0xFFu8).chain(bytes).peekable();
+        let offset = offset - padding as u32;
+
+        // pointer and offset in 32-bit words
+        let ptr = self.region().base_address() as *mut u32;
+        let mut offset = offset as usize / core::mem::size_of::<u32>();
+        let write_size =
+            USER_FLASH_MAX_WRITE_SIZE / core::mem::size_of::<u32>();
+
+        // Clear all the error flags due to previous programming/erase
+        self.flash.clear_error_flags();
+
+        // Iterate over buffers of size `write_size`
+        while bytes.peek().is_some() {
+            // Ensure that the write to the CR register (device memory) is
+            // committed *before* we write to flash (normal memory). This
+            // prevents ProgrammingSequence errors
+            fence(Ordering::SeqCst);
+
+            for _ in 0..write_size {
+                let b0 = bytes.next().unwrap_or(&0xFF);
+                let b1 = bytes.next().unwrap_or(&0xFF);
+                let b2 = bytes.next().unwrap_or(&0xFF);
+                let b3 = bytes.next().unwrap_or(&0xFF);
+
+                let word = u32::from_le_bytes([*b0, *b1, *b2, *b3]);
+                unsafe {
+                    ptr::write_volatile(ptr.add(offset), word);
+                }
+                offset += 1;
+            }
+
+            // Ensure that the writes to flash (normal memory) are committed
+            // before we start polling the status register. The write will have
+            // already started once the last word was written, so this fence
+            // does not cause any additional slowdown
+            fence(Ordering::SeqCst);
+
+            self.flash.wait_ready();
+            self.flash.check_error()?;
+        }
+
+        Ok(())
+    }
+}
+
+impl NorFlash for UnlockedUserFlash<'_> {
+    const WRITE_SIZE: usize = super::USER_FLASH_MAX_WRITE_SIZE;
+    const ERASE_SIZE: usize = super::SECTOR_SIZE;
+
+    fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+        let mut current = from;
+
+        for (bank, sector) in self.region().bank_sector_iter() {
+            if sector.contains(current) {
+                self.erase_sector(bank, sector.number as usize)?;
+                current += super::SECTOR_SIZE as u32;
+            }
+            if current >= to {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
+        self.program(offset, bytes.iter())
+    }
+}
+
+impl<'a> UnlockedOtpData<'a> {
+    pub fn program_value(
+        &mut self,
+        slot: usize,
+        val: u16,
+    ) -> Result<u16, Error> {
+        assert!(slot < OTP_NUM_SLOTS);
+
+        self.flash.wait_ready();
+
+        // TODO: Check if block is locked
+        {
+            // Unlock programming and ensure it is locked again on drop (at the end of this block)
+            let _request = self.flash.programming_request()?;
+
+            // Clear all the error flags due to previous programming/erase
+            self.flash.clear_error_flags();
+
+            // Ensure that the write to the CR register (device memory) is
+            // committed *before* we write to flash (normal memory). This
+            // prevents ProgrammingSequence errors
+            fence(Ordering::SeqCst);
+
+            let ptr = self.region().base_address() as *mut u16;
+            unsafe { core::ptr::write_volatile(ptr.add(slot), val) }
+
+            // Ensure that the writes to flash (normal memory) are committed
+            // before we start polling the status register. The write will have
+            // already started once the last word was written, so this fence
+            // does not cause any additional slowdown
+            fence(Ordering::SeqCst);
+
+            self.flash.wait_ready();
+            self.flash.check_error()?;
+        }
+        self.read_value(slot)
+    }
+
+    pub fn program_sequence<I>(
+        &mut self,
+        start_slot: usize,
+        words: I,
+    ) -> Result<(), Error>
+    where
+        I: Iterator<Item = &'a u16>,
+    {
+        assert!(start_slot < OTP_NUM_SLOTS);
+
+        let base_ptr = self.region().base_address() as *mut u16;
+        self.flash.wait_ready();
+        {
+            // Unlock programming and ensure it is locked again on drop (at the end of this block)
+            let _request = self.flash.programming_request()?;
+
+            // Clear all the error flags due to previous programming/erase
+            self.flash.clear_error_flags();
+
+            for (slot, word) in words.enumerate() {
+                // Ensure that the write to the CR register (device memory) is
+                // committed *before* we write to flash (normal memory). This
+                // prevents ProgrammingSequence errors
+                fence(Ordering::SeqCst);
+
+                let ptr = unsafe { base_ptr.add(start_slot + slot) };
+
+                assert!(ptr < self.region().region_end_address() as *mut u16);
+                unsafe { core::ptr::write_volatile(ptr, *word) }
+
+                // Ensure that the writes to flash (normal memory) are committed
+                // before we start polling the status register. The write will have
+                // already started once the last word was written, so this fence
+                // does not cause any additional slowdown
+                fence(Ordering::SeqCst);
+
+                self.flash.wait_ready();
+                self.flash.check_error()?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn program_bytes<I>(
+        &mut self,
+        offset: usize,
+        bytes: I,
+    ) -> Result<(), Error>
+    where
+        I: Iterator<Item = &'a u8>,
+    {
+        let base_ptr = self.region().base_address() as *mut u8;
+        let start_ptr = unsafe { base_ptr.add(offset) } as *mut u16;
+        assert!(start_ptr.is_aligned());
+
+        let mut bytes = bytes.peekable();
+        self.flash.wait_ready();
+        {
+            // Unlock programming and ensure it is locked again on drop (at the end of this block)
+            let _request = self.flash.programming_request()?;
+
+            // Clear all the error flags due to previous programming/erase
+            self.flash.clear_error_flags();
+
+            let mut count = 0usize;
+
+            while bytes.peek().is_some() {
+                // Ensure that the write to the CR register (device memory) is
+                // committed *before* we write to flash (normal memory). This
+                // prevents ProgrammingSequence errors
+                fence(Ordering::SeqCst);
+
+                let b0 = bytes.next().unwrap_or(&0xFF);
+                let b1 = bytes.next().unwrap_or(&0xFF);
+                let word = u16::from_le_bytes([*b0, *b1]);
+
+                let ptr = unsafe { start_ptr.add(count) };
+                assert!(ptr < self.region().region_end_address() as *mut u16);
+
+                unsafe { core::ptr::write_volatile(ptr, word) }
+
+                // Ensure that the writes to flash (normal memory) are committed
+                // before we start polling the status register. The write will have
+                // already started once the last word was written, so this fence
+                // does not cause any additional slowdown
+                fence(Ordering::SeqCst);
+
+                self.flash.wait_ready();
+                self.flash.check_error()?;
+                count += 1;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> UnlockedOptionBytes<'a> {
+    pub fn modify<F>(&mut self, f: F) -> Result<(), Error>
+    where
+        F: FnOnce(&mut FLASH),
+    {
+        self.flash.prepare_operation()?;
+
+        // Ensure that the write to the CR register (device memory) is
+        // committed *before* we write to flash (normal memory). This
+        // prevents ProgrammingSequence errors
+        fence(Ordering::SeqCst);
+
+        f(&mut self.flash.flash);
+
+        self.flash.optcr().modify(|_, w| w.optstrt().set_bit());
+
+        // Ensure that the writes to flash (normal memory) are committed
+        // before we start polling the status register. The write will have
+        // already started once the last word was written, so this fence
+        // does not cause any additional slowdown
+        fence(Ordering::SeqCst);
+
+        self.flash.wait_ready();
+        self.flash.check_error()?;
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,12 @@ pub mod gpdma;
 pub mod serial;
 
 #[cfg(feature = "device-selected")]
+pub mod signature;
+
+#[cfg(feature = "device-selected")]
+pub mod flash;
+
+#[cfg(feature = "device-selected")]
 mod sealed {
     pub trait Sealed {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,14 +89,13 @@ pub mod gpdma;
 pub mod serial;
 
 #[cfg(feature = "device-selected")]
-<<<<<<< la/flash
 pub mod signature;
 
 #[cfg(feature = "device-selected")]
 pub mod flash;
-=======
+
+#[cfg(feature = "device-selected")]
 pub mod crc;
->>>>>>> master
 
 #[cfg(feature = "device-selected")]
 mod sealed {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,6 +2,7 @@
 
 pub use crate::delay::DelayExt as _stm32h5xx_hal_delay_DelayExt;
 pub use crate::dwt::DwtExt as _stm32h5xx_hal_delay_DwtExt;
+pub use crate::flash::FlashExt as _stm32h5xx_hal_flash_FlashExt;
 pub use crate::gpdma::GpdmaExt as _stm32h5xx_hal_gpdma_GpdmaExt;
 pub use crate::gpio::GpioExt as _stm32h5xx_hal_gpio_GpioExt;
 pub use crate::i2c::I2cExt as _stm32h5xx_hal_i2c_I2cExt;

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -503,7 +503,12 @@ impl Rcc {
         let flash = unsafe { &(*FLASH::ptr()) };
         // Adjust flash wait states
         flash.acr().write(|w| unsafe {
-            w.wrhighfreq().bits(progr_delay).latency().bits(wait_states)
+            w.wrhighfreq().bits(progr_delay).latency().bits(wait_states);
+            if wait_states > 0 {
+                w.prften().set_bit()
+            } else {
+                w.prften().clear_bit()
+            }
         });
         while flash.acr().read().latency().bits() != wait_states {}
     }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -2,15 +2,22 @@
 //!
 //! (stored in system flash memory)
 
-/// Uniqure Device ID register
+/// Unique Device ID register
+/// 96 bits of unique device ID, factory programmed and read-only
 pub struct Uid;
 
-const UID_PTR: *const u8 = 0x08FF_F800 as _;
+const UID_PTR: *const u32 = 0x08FF_F800 as _;
 
 impl Uid {
-    /// Read Unique Device ID
-    pub fn read() -> &'static [u8; 12] {
-        unsafe { &*UID_PTR.cast::<[u8; 12]>() }
+    /// Read Unique Device ID as three 32-bit words.
+    pub fn read() -> [u32; 3] {
+        unsafe {
+            [
+                core::ptr::read_volatile(UID_PTR),
+                core::ptr::read_volatile(UID_PTR.add(1)),
+                core::ptr::read_volatile(UID_PTR.add(2)),
+            ]
+        }
     }
 }
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,0 +1,33 @@
+//! Device electronic signature
+//!
+//! (stored in system flash memory)
+
+/// Uniqure Device ID register
+pub struct Uid;
+
+const UID_PTR: *const u8 = 0x08FF_F800 as _;
+
+impl Uid {
+    /// Read Unique Device ID
+    pub fn read() -> &'static [u8; 12] {
+        unsafe { &*UID_PTR.cast::<[u8; 12]>() }
+    }
+}
+
+/// Size of integrated flash
+pub struct FlashSize;
+
+const FLASH_SIZE_PTR: *const u16 = 0x08FF_F80C as _;
+
+impl FlashSize {
+    /// Read flash size in kilobytes
+    pub fn kilo_bytes() -> usize {
+        let size = unsafe { *FLASH_SIZE_PTR };
+        size as usize
+    }
+
+    /// Read flash size in bytes
+    pub fn bytes() -> usize {
+        Self::kilo_bytes() * 1024
+    }
+}


### PR DESCRIPTION
Adds an embedded flash driver targeting the STM32H503 (RM0492). Implements embedded-storage traits for user flash, one time programmable data, and option bytes.

  What's included

   - User flash — NorFlash + ReadNorFlash implementations
   - OTP data — program_value, program_sequence, program_bytes
   - Option bytes — UnlockedOptionBytes::modify for applying option-byte changes via OPTSTRT.
   - Lock/unlock discipline — all write guards (UnlockedUserFlash, UnlockedOtpData, UnlockedOptionBytes) re-lock their
  respective control registers on drop.
   - FlashSize + Uid helpers in src/signature.rs.
   - Three examples: flash.rs, flash_otp.rs, flash_option_bytes.rs.
