### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,17 +84,17 @@ stm32-usbd = "0.8.0"
 [dev-dependencies]
 log = { version = "0.4.20"}
 cortex-m-rt = "0.7.3"
-defmt-rtt = { version = "0.4.0" }
-panic-halt = "0.2.0"
-panic-rtt-target = { version = "0.1.0", features = ["cortex-m"] }
+defmt-rtt = { version = "1.3.0" }
+panic-halt = "1.0.0"
+panic-rtt-target = { version = "0.2.0" }
 cfg-if = "1.0.0"
-rtt-target = "0.5.0"
+rtt-target = "0.6.2"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 cortex-m-log = { version = "0.8.0", features = ["itm", "semihosting", "log-integration"] }
-cortex-m-semihosting = "0.5.0"
+cortex-m-semihosting = "0.6.0"
 panic-itm = { version = "~0.4.1" }
-panic-probe = "0.3.2"
-panic-semihosting = "0.6"
+panic-probe = "1.0.0"
+panic-semihosting = "0.7.0"
 usbd-serial = "0.2.2"
 usb-device = { version = "0.3.2", features = ["defmt", "log"] }
 


### PR DESCRIPTION
This updates all dependencies, except for fugit, which is updated in #80, due to API breakages.